### PR TITLE
throw exception when not existing data is accessed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* throw an exception when not existing document data is accessed instead of
+  failing with a PHP notice
+
 * all values of a score are optional, pass `null` to omit them
 
 * values passed to the constructor of the `Score` class are no longer cast to

--- a/spec/ActivityProfileDocumentSpec.php
+++ b/spec/ActivityProfileDocumentSpec.php
@@ -31,6 +31,11 @@ class ActivityProfileDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
+    function it_throws_exception_when_not_existing_data_is_being_read()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
+    }
+
     function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');

--- a/spec/AgentProfileDocumentSpec.php
+++ b/spec/AgentProfileDocumentSpec.php
@@ -32,6 +32,11 @@ class AgentProfileDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
+    function it_throws_exception_when_not_existing_data_is_being_read()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
+    }
+
     function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');

--- a/spec/StateDocumentSpec.php
+++ b/spec/StateDocumentSpec.php
@@ -35,6 +35,11 @@ class StateDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
+    function it_throws_exception_when_not_existing_data_is_being_read()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
+    }
+
     function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');

--- a/src/DocumentData.php
+++ b/src/DocumentData.php
@@ -47,6 +47,10 @@ final class DocumentData implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
+        if (!isset($this->data[$offset])) {
+            throw new \InvalidArgumentException(sprintf('No data for name "%s" registered.', $offset));
+        }
+
         return $this->data[$offset];
     }
 


### PR DESCRIPTION
Previously, accessing document data for a key that did not exist led to
a PHP notice for an undefined index.
