### PR TITLE
activity definition properties are optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* all values of an activity definition are optional, pass `null` to omit them
+
 * all values of a result are optional, pass `null` to omit them
 
 * throw an exception when not existing document data is accessed instead of

--- a/spec/DefinitionSpec.php
+++ b/spec/DefinitionSpec.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Xabbuh\XApi\Model;
+
+use PhpSpec\ObjectBehavior;
+
+class DefinitionSpec extends ObjectBehavior
+{
+    function its_properties_can_be_read()
+    {
+        $this->beConstructedWith(
+            array('en-US' => 'test'),
+            array('en-US' => 'test'),
+            'http://id.tincanapi.com/activitytype/unit-test'
+        );
+
+        $name = $this->getName();
+        $name->shouldBeArray();
+        $name->shouldHaveCount(1);
+        $name->shouldHaveKeyWithValue('en-US', 'test');
+
+        $description = $this->getName();
+        $description->shouldBeArray();
+        $description->shouldHaveCount(1);
+        $description->shouldHaveKeyWithValue('en-US', 'test');
+
+        $this->getType()->shouldReturn('http://id.tincanapi.com/activitytype/unit-test');
+    }
+
+    function it_can_be_empty()
+    {
+        $this->getName()->shouldReturn(null);
+        $this->getDescription()->shouldReturn(null);
+        $this->getType()->shouldReturn(null);
+    }
+}

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -36,7 +36,12 @@ final class Definition
      */
     private $type;
 
-    public function __construct(array $name, array $description, $type)
+    /**
+     * @param array|null  $name
+     * @param array|null  $description
+     * @param string|null $type
+     */
+    public function __construct(array $name = null, array $description = null, $type = null)
     {
         $this->name = $name;
         $this->description = $description;


### PR DESCRIPTION
Even though the properties are recommended they aren't strictly required
by the xAPI spec and therefore it must be possible to pass `null` for
each of them.
