### PR TITLE
add the moreInfo property to activity definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.3.0
+-----
+
+* added the possibility to attach an IRL to an activity definition that acts as
+  a reference to a document that contains human-readable information about the
+  activity
+
 * all values of an activity definition are optional, pass `null` to omit them
 
 * all values of a result are optional, pass `null` to omit them

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2.x-dev"
+            "dev-master": "0.3.x-dev"
         }
     }
 }

--- a/spec/DefinitionSpec.php
+++ b/spec/DefinitionSpec.php
@@ -20,7 +20,8 @@ class DefinitionSpec extends ObjectBehavior
         $this->beConstructedWith(
             array('en-US' => 'test'),
             array('en-US' => 'test'),
-            'http://id.tincanapi.com/activitytype/unit-test'
+            'http://id.tincanapi.com/activitytype/unit-test',
+            'https://github.com/adlnet/xAPI_LRS_Test'
         );
 
         $name = $this->getName();
@@ -34,6 +35,7 @@ class DefinitionSpec extends ObjectBehavior
         $description->shouldHaveKeyWithValue('en-US', 'test');
 
         $this->getType()->shouldReturn('http://id.tincanapi.com/activitytype/unit-test');
+        $this->getMoreInfo()->shouldReturn('https://github.com/adlnet/xAPI_LRS_Test');
     }
 
     function it_can_be_empty()
@@ -41,5 +43,6 @@ class DefinitionSpec extends ObjectBehavior
         $this->getName()->shouldReturn(null);
         $this->getDescription()->shouldReturn(null);
         $this->getType()->shouldReturn(null);
+        $this->getMoreInfo()->shouldReturn(null);
     }
 }

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -37,15 +37,24 @@ final class Definition
     private $type;
 
     /**
+     * An IRL where human-readable information describing the {@link Activity} can be found.
+     *
+     * @var string|null
+     */
+    private $moreInfo;
+
+    /**
      * @param array|null  $name
      * @param array|null  $description
      * @param string|null $type
+     * @param string|null $moreInfo
      */
-    public function __construct(array $name = null, array $description = null, $type = null)
+    public function __construct(array $name = null, array $description = null, $type = null, $moreInfo = null)
     {
         $this->name = $name;
         $this->description = $description;
         $this->type = $type;
+        $this->moreInfo = $moreInfo;
     }
 
     /**
@@ -79,6 +88,16 @@ final class Definition
     }
 
     /**
+     * Returns an IRL where human-readable information about the activity can be found.
+     *
+     * @return string|null
+     */
+    public function getMoreInfo()
+    {
+        return $this->moreInfo;
+    }
+
+    /**
      * Checks if another definition is equal.
      *
      * Two definitions are equal if and only if all of their properties are equal.
@@ -90,6 +109,10 @@ final class Definition
     public function equals(Definition $definition)
     {
         if ($this->type !== $definition->type) {
+            return false;
+        }
+
+        if ($this->moreInfo !== $definition->moreInfo) {
             return false;
         }
 


### PR DESCRIPTION
THis property is an IRL that resolves to a document containing
human-readable information about the activity.
