### PR TITLE
changed the default display value to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 0.3.0
 -----
 
+* changed the default value of the `display` property of the `Verb` class to
+  `null` (was the empty array before) to make it possible to distinguish the
+  empty list from the case when the `display` property was omitted
+
 * added the possibility to attach an IRL to an activity definition that acts as
   a reference to a document that contains human-readable information about the
   activity

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,12 @@
 UPGRADE
 =======
 
+Upgrading from 0.2 to 0.3
+-------------------------
+
+* The default value of the `display` property of the `Verb` class was changed
+  to `null` (was the empty array before).
+
 Upgrading from 0.2.0 to 0.2.1
 -----------------------------
 

--- a/spec/VerbSpec.php
+++ b/spec/VerbSpec.php
@@ -29,6 +29,14 @@ class VerbSpec extends ObjectBehavior
         $this->getDisplay()->shouldReturn(array('en-US' => 'test'));
     }
 
+    function its_display_property_is_null_if_omitted()
+    {
+        $this->beConstructedWith('http://tincanapi.com/conformancetest/verbid');
+
+        $this->getId()->shouldReturn('http://tincanapi.com/conformancetest/verbid');
+        $this->getDisplay()->shouldReturn(null);
+    }
+
     function it_creates_voiding_verb_through_factory_method()
     {
         $this->beConstructedThrough(array('Xabbuh\XApi\Model\Verb', 'createVoidVerb'));

--- a/src/Verb.php
+++ b/src/Verb.php
@@ -26,7 +26,7 @@ final class Verb
 
     /**
      * Human readable representation of the verb in one or more languages
-     * @var array
+     * @var array|null
      */
     private $display;
 
@@ -34,7 +34,7 @@ final class Verb
      * @param string $id
      * @param array  $display
      */
-    public function __construct($id, array $display = array())
+    public function __construct($id, array $display = null)
     {
         $this->id = $id;
         $this->display = $display;
@@ -53,7 +53,7 @@ final class Verb
     /**
      * Returns the human readable representation of the Verb in one or more languages.
      *
-     * @return array The language map
+     * @return array|null The language map
      */
     public function getDisplay()
     {


### PR DESCRIPTION
This way it is possible to decide whether the property was omitted when
building the Verb instance or an empty list was passed on intent.
