### PR TITLE
remove a sub statement's id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 0.5.0
 -----
 
+* Remove the `$id` property from the `SubStatement` class as a sub statement
+  must not have an id.
+
 * added a `$context` attribute to `SubStatement` instances
 
 * added `equals()` method to the `Result` model class

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,13 @@
 UPGRADE
 =======
 
+Upgrading from 0.4 to 0.5
+-------------------------
+
+* The `$id` attribute has been removed from the `SubStatement` class. Also,
+  the `$id` argument of the class constructor has been removed respectively.
+  The first constructor argument is now the sub statement's actor.
+
 Upgrading from 0.3 to 0.4
 -------------------------
 

--- a/spec/SubStatementSpec.php
+++ b/spec/SubStatementSpec.php
@@ -30,7 +30,7 @@ class SubStatementSpec extends ObjectBehavior
         $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:conformancetest@tincanapi.com'));
         $verb = new Verb('http://tincanapi.com/conformancetest/verbid', array('en-US' => 'test'));
         $object = new Activity('http://tincanapi.com/conformancetest/activityid');
-        $this->beConstructedWith('16fd2706-8baf-433b-82eb-8c7fada847da', $actor, $verb, $object);
+        $this->beConstructedWith($actor, $verb, $object);
 
         $this->shouldHaveType('Xabbuh\XApi\Model\Object');
     }
@@ -40,9 +40,9 @@ class SubStatementSpec extends ObjectBehavior
         $actor = new Agent(InverseFunctionalIdentifier::withMbox('mailto:conformancetest@tincanapi.com'));
         $verb = new Verb('http://tincanapi.com/conformancetest/verbid', array('en-US' => 'test'));
         $object = new Activity('http://tincanapi.com/conformancetest/activityid');
-        $this->beConstructedWith('16fd2706-8baf-433b-82eb-8c7fada847da', $actor, $verb, $object, null, new Context());
+        $this->beConstructedWith($actor, $verb, $object, null, new Context());
 
-        $subStatement = new SubStatement('16fd2706-8baf-433b-82eb-8c7fada847da', $actor, $verb, $object);
+        $subStatement = new SubStatement($actor, $verb, $object);
 
         $this->equals($subStatement)->shouldReturn(false);
 
@@ -62,7 +62,7 @@ class SubStatementSpec extends ObjectBehavior
             ->withStatement(new StatementReference('16fd2706-8baf-433b-82eb-8c7fada847da'))
             ->withExtensions(new Extensions(array()))
         ;
-        $subStatement = new SubStatement('16fd2706-8baf-433b-82eb-8c7fada847da', $actor, $verb, $object, null, $context);
+        $subStatement = new SubStatement($actor, $verb, $object, null, $context);
 
         $this->equals($subStatement)->shouldReturn(false);
     }

--- a/src/SubStatement.php
+++ b/src/SubStatement.php
@@ -19,11 +19,6 @@ namespace Xabbuh\XApi\Model;
 final class SubStatement extends Object
 {
     /**
-     * @var string The unique identifier
-     */
-    private $id;
-
-    /**
      * @var Verb $verb The {@link Verb}
      */
     private $verb;
@@ -48,24 +43,13 @@ final class SubStatement extends Object
      */
     private $context;
 
-    public function __construct($id, Actor $actor, Verb $verb, Object $object, Result $result = null, Context $context = null)
+    public function __construct(Actor $actor, Verb $verb, Object $object, Result $result = null, Context $context = null)
     {
-        $this->id = $id;
         $this->actor = $actor;
         $this->verb = $verb;
         $this->object = $object;
         $this->result = $result;
         $this->context = $context;
-    }
-
-    /**
-     * Returns the Statement's unique identifier.
-     *
-     * @return string The identifier
-     */
-    public function getId()
-    {
-        return $this->id;
     }
 
     /**
@@ -168,10 +152,6 @@ final class SubStatement extends Object
         }
 
         /** @var SubStatement $statement */
-
-        if ($this->id !== $statement->id) {
-            return false;
-        }
 
         if (!$this->actor->equals($statement->actor)) {
             return false;


### PR DESCRIPTION
According to the specs, a sub statement must not have the id property.
