### PR TITLE
Add a StateDocumentsFilter class

### DIFF
--- a/spec/StateDocumentsFilterSpec.php
+++ b/spec/StateDocumentsFilterSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Xabbuh\XApi\Model;
+
+use PhpSpec\ObjectBehavior;
+use Xabbuh\XApi\Model\Activity;
+use Xabbuh\XApi\Model\Agent;
+use Xabbuh\XApi\Model\InverseFunctionalIdentifier;
+use Xabbuh\XApi\Model\IRI;
+use Xabbuh\XApi\Model\LanguageMap;
+use Xabbuh\XApi\Model\Verb;
+
+class StateDocumentsFilterSpec extends ObjectBehavior
+{
+    function it_does_not_filter_anything_by_default()
+    {
+        $filter = $this->getFilter();
+        $filter->shouldHaveCount(0);
+    }
+
+    function it_can_filter_by_activity()
+    {
+        $this->byActivity(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')))->shouldReturn($this);
+
+        $filter = $this->getFilter();
+        $filter->shouldHaveCount(1);
+        $filter->shouldHaveKeyWithValue('activity', 'http://tincanapi.com/conformancetest/activityid');
+    }
+
+    function it_can_filter_by_agent()
+    {
+        $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
+        $this->byAgent($actor)->shouldReturn($this);
+
+        $filter = $this->getFilter();
+        $filter->shouldHaveCount(1);
+        $filter->shouldHaveKeyWithValue('agent', $actor);
+    }
+
+    function it_can_filter_by_registration()
+    {
+        $this->byRegistration('foo')->shouldReturn($this);
+
+        $filter = $this->getFilter();
+        $filter->shouldHaveCount(1);
+        $filter->shouldHaveKeyWithValue('registration', 'foo');
+    }
+
+    function it_can_filter_by_timestamp()
+    {
+        $this->since(\DateTime::createFromFormat(\DateTime::ISO8601, '2013-05-18T05:32:34Z'))->shouldReturn($this);
+        $this->getFilter()->shouldHaveKeyWithValue('since', '2013-05-18T05:32:34+00:00');
+    }
+}

--- a/src/StateDocumentsFilter.php
+++ b/src/StateDocumentsFilter.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the xAPI package.
+ *
+ * (c) Christian Flothmann <christian.flothmann@xabbuh.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xabbuh\XApi\Model;
+
+/**
+ * Filter to apply on GET requests to the states API.
+ *
+ * @author Jérôme Parmentier <jerome.parmentier@acensi.fr>
+ */
+class StateDocumentsFilter
+{
+    /**
+     * @var array The generated filter
+     */
+    private $filter = array();
+
+    /**
+     * Filter by an Activity.
+     *
+     * @param Activity $activity The Activity to filter by
+     *
+     * @return $this
+     */
+    public function byActivity(Activity $activity)
+    {
+        $this->filter['activity'] = $activity->getId()->getValue();
+
+        return $this;
+    }
+
+    /**
+     * Filters by an Agent.
+     *
+     * @param Agent $agent The Agent to filter by
+     *
+     * @return $this
+     */
+    public function byAgent(Agent $agent)
+    {
+        $this->filter['agent'] = $agent;
+
+        return $this;
+    }
+
+    /**
+     * Filters for State documents matching the given registration id.
+     *
+     * @param string $registration A registration id
+     *
+     * @return $this
+     */
+    public function byRegistration($registration)
+    {
+        $this->filter['registration'] = $registration;
+
+        return $this;
+    }
+
+    /**
+     * Filters for State documents stored since the specified timestamp (exclusive).
+     *
+     * @param \DateTime $timestamp The timestamp
+     *
+     * @return $this
+     */
+    public function since(\DateTime $timestamp)
+    {
+        $this->filter['since'] = $timestamp->format('c');
+
+        return $this;
+    }
+
+    /**
+     * Returns the generated filter.
+     *
+     * @return array The filter
+     */
+    public function getFilter()
+    {
+        return $this->filter;
+    }
+}


### PR DESCRIPTION
Prepare the implementation of https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#23-state-resource

Basically, what I have in mind is to mimic the implementation for Statements by adding : 
- a filter class in this package (this PR)
- a repository interface in the `php-xapi/repository-api` package
- a serializer interface in the `php-xapi/serializer` package

Then do the works in our LrsBundle.