### PR TITLE
Deprecate Statement::getTimestamp()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 CHANGELOG
 =========
 
+1.2.0
+-----
+
+* The `Statement::getTimestamp()` method is deprecated and will be removed in
+  3.0. Use `Statement::getCreated()` instead.
+
 1.1.1
 -----
 
 * Added missing `$version` attribute to the `Statement` class which defaults to
   `1.0.0`.
-* The `Statement::getTimestamp()` method is deprecated and will be removed in
-  3.0. Use `Statement::getCreated()` instead.
 
 1.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * Added missing `$version` attribute to the `Statement` class which defaults to
   `1.0.0`.
+* The `Statement::getTimestamp()` method is deprecated and will be removed in
+  3.0. Use `Statement::getCreated()` instead.
 
 1.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * The `Statement::getTimestamp()` method is deprecated and will be removed in
   3.0. Use `Statement::getCreated()` instead.
+* The `Statement::withTimestamp()` method is deprecated and will be removed in
+  3.0. Use `Statement::withCreated()` instead.
 
 1.1.1
 -----

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -151,10 +151,23 @@ final class Statement
         return $statement;
     }
 
+    /**
+     * @deprecated since 1.2, to be removed in 3.0
+     */
     public function withTimestamp(\DateTime $timestamp = null)
     {
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.2 and will be removed in 3.0. Use "%s::withCreated()" method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+
         $statement = clone $this;
         $statement->created = $timestamp;
+
+        return $statement;
+    }
+
+    public function withCreated(\DateTime $created = null)
+    {
+        $statement = clone $this;
+        $statement->created = $created;
 
         return $statement;
     }

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -266,10 +266,14 @@ final class Statement
      * occurred.
      *
      * @return \DateTime The timestamp
+     *
+     * @deprecated since 1.1.1, to be removed in 3.0
      */
     public function getTimestamp()
     {
-        return $this->created;
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.1.1 and will be removed in 3.0. Use "%s::getCreated()" method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+
+        return $this->getCreated();
     }
 
     /**

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -267,13 +267,13 @@ final class Statement
      *
      * @return \DateTime The timestamp
      *
-     * @deprecated since 1.1.1, to be removed in 3.0
+     * @deprecated since 1.2, to be removed in 3.0
      */
     public function getTimestamp()
     {
         @trigger_error(sprintf('The "%s()" method is deprecated since 1.1.1 and will be removed in 3.0. Use "%s::getCreated()" method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
-        return $this->getCreated();
+        return $this->created;
     }
 
     /**

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -271,7 +271,7 @@ final class Statement
      */
     public function getTimestamp()
     {
-        @trigger_error(sprintf('The "%s()" method is deprecated since 1.1.1 and will be removed in 3.0. Use "%s::getCreated()" method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since 1.2 and will be removed in 3.0. Use "%s::getCreated()" method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         return $this->created;
     }


### PR DESCRIPTION
Let's not have 2 getters that does the same.