### PR TITLE
default statement version is empty

### DIFF
--- a/spec/StatementSpec.php
+++ b/spec/StatementSpec.php
@@ -38,9 +38,9 @@ class StatementSpec extends ObjectBehavior
         $this->beConstructedWith($id, $actor, $verb, $object);
     }
 
-    function its_default_version_is_1_0_0()
+    function its_default_version_is_null()
     {
-        $this->getVersion()->shouldReturn('1.0.0');
+        $this->getVersion()->shouldReturn(null);
     }
 
     function it_creates_reference_to_itself()

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -78,9 +78,9 @@ final class Statement
      * @param \DateTime|null    $stored
      * @param Context|null      $context
      * @param Attachment[]|null $attachments
-     * @param string            $version
+     * @param string|null       $version
      */
-    public function __construct(StatementId $id = null, Actor $actor, Verb $verb, Object $object, Result $result = null, Actor $authority = null, \DateTime $created = null, \DateTime $stored = null, Context $context = null, array $attachments = null, $version = '1.0.0')
+    public function __construct(StatementId $id = null, Actor $actor, Verb $verb, Object $object, Result $result = null, Actor $authority = null, \DateTime $created = null, \DateTime $stored = null, Context $context = null, array $attachments = null, $version = null)
     {
         $this->id = $id;
         $this->actor = $actor;


### PR DESCRIPTION
According to https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#user-content-statement-properties and https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#learning-record-provider-requirements-2 it is not recommended to include the version attribute when constructing statements.