### PR TITLE
Add automated code quality tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,8 +53,8 @@ jobs:
 
       - name: 'Run coding standard checks'
         run: |
-          vendor/bin/ecs check
           vendor/bin/rector process -n
+          vendor/bin/ecs check
         if: ${{ matrix.quality-check }}
 
       - name: 'Run PhpSpec'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
             composer-options: '--prefer-stable'
           - php-version: '8.0'
             composer-options: '--prefer-stable'
+            quality-check: true
 
     steps:
       - name: 'Check out'
@@ -49,6 +50,12 @@ jobs:
         env:
           COMPOSER_OPTIONS: '${{ matrix.composer-options }}'
         run: 'composer update --no-progress $COMPOSER_OPTIONS'
+
+      - name: 'Run coding standard checks'
+        run: |
+          vendor/bin/ecs check
+          vendor/bin/rector process -n
+        if: ${{ matrix.quality-check }}
 
       - name: 'Run PhpSpec'
         run: 'vendor/bin/phpspec run'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^5.0 || ^6.0 || ^7.0",
-        "symplify/easy-coding-standard": "^9.4"
+        "symplify/easy-coding-standard": "^9.4",
+        "rector/rector": "^0.11.36"
     },
     "conflict": {
         "xabbuh/xapi-model": "*"

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,16 @@
     "keywords": ["xAPI", "Experience API", "Tin Can API", "models"],
     "homepage": "https://github.com/php-xapi/model",
     "license": "MIT",
+    "scripts" : {
+        "lint:fix": [
+            "@php vendor/bin/rector process",
+            "@php vendor/bin/ecs check --fix"
+        ],
+        "lint:check": [
+            "@php vendor/bin/rector process -n",
+            "@php vendor/bin/ecs check"
+        ]
+    },
     "authors": [
         {
             "name": "Christian Flothmann",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "ramsey/uuid": "^2.9 || ^3.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.0 || ^6.0 || ^7.0"
+        "phpspec/phpspec": "^5.0 || ^6.0 || ^7.0",
+        "symplify/easy-coding-standard": "^9.4"
     },
     "conflict": {
         "xabbuh/xapi-model": "*"

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/spec',
+    ]);
+
+    // run and fix, one by one
+    $containerConfigurator->import(SetList::CLEAN_CODE);
+    $containerConfigurator->import(SetList::PSR_12);
+};

--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
@@ -12,6 +11,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PATHS, [
         __DIR__ . '/src',
         __DIR__ . '/spec',
+        __DIR__ . '/ecs.php',
+        __DIR__ . '/rector.php',
     ]);
 
     // run and fix, one by one

--- a/rector.php
+++ b/rector.php
@@ -9,15 +9,16 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
-
     $parameters->set(Option::PATHS, [
         __DIR__ . '/src',
         __DIR__ . '/spec',
+        __DIR__ . '/ecs.php',
+        __DIR__ . '/rector.php',
     ]);
+
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
 
     $containerConfigurator->import(SetList::DEAD_CODE);
-    $containerConfigurator->import(SetList::PHP_72);
     $containerConfigurator->import(SetList::CODE_QUALITY);
-
+    $containerConfigurator->import(SetList::PHP_72);
 };

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/spec',
+    ]);
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_72);
+
+    $containerConfigurator->import(SetList::DEAD_CODE);
+    $containerConfigurator->import(SetList::PHP_72);
+    $containerConfigurator->import(SetList::CODE_QUALITY);
+
+};

--- a/spec/AccountSpec.php
+++ b/spec/AccountSpec.php
@@ -17,7 +17,7 @@ use Xabbuh\XApi\Model\IRL;
 
 class AccountSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $this->beConstructedWith('test', IRL::fromString('https://tincanapi.com'));
 
@@ -25,21 +25,21 @@ class AccountSpec extends ObjectBehavior
         $this->getHomePage()->equals(IRL::fromString('https://tincanapi.com'))->shouldReturn(true);
     }
 
-    function it_is_not_equal_to_other_account_if_name_are_not_equal()
+    public function it_is_not_equal_to_other_account_if_name_are_not_equal()
     {
         $this->beConstructedWith('foo', IRL::fromString('https://tincanapi.com'));
 
         $this->equals(new Account('bar', IRL::fromString('https://tincanapi.com')))->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_account_if_home_pages_are_not_equal()
+    public function it_is_not_equal_to_other_account_if_home_pages_are_not_equal()
     {
         $this->beConstructedWith('test', IRL::fromString('https://tincanapi.com'));
 
         $this->equals(new Account('test', IRL::fromString('https://tincanapi.com/OAuth/Token')))->shouldReturn(false);
     }
 
-    function it_is_equal_to_other_account_if_all_properties_are_equal()
+    public function it_is_equal_to_other_account_if_all_properties_are_equal()
     {
         $this->beConstructedWith('test', IRL::fromString('https://tincanapi.com'));
 

--- a/spec/ActivityProfileDocumentSpec.php
+++ b/spec/ActivityProfileDocumentSpec.php
@@ -20,20 +20,20 @@ use Xabbuh\XApi\Model\IRI;
 
 class ActivityProfileDocumentSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->beConstructedWith(new ActivityProfile('id', new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))), new DocumentData(array(
+        $this->beConstructedWith(new ActivityProfile('id', new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))), new DocumentData([
             'x' => 'foo',
             'y' => 'bar',
-        )));
+        ]));
     }
 
-    function it_is_a_document()
+    public function it_is_a_document()
     {
         $this->shouldHaveType(Document::class);
     }
 
-    function its_data_can_be_read()
+    public function its_data_can_be_read()
     {
         $this->offsetExists('x')->shouldReturn(true);
         $this->offsetGet('x')->shouldReturn('foo');
@@ -42,12 +42,12 @@ class ActivityProfileDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
-    function it_throws_exception_when_not_existing_data_is_being_read()
+    public function it_throws_exception_when_not_existing_data_is_being_read()
     {
         $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
     }
 
-    function its_data_cannot_be_manipulated()
+    public function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetUnset('x');

--- a/spec/ActivitySpec.php
+++ b/spec/ActivitySpec.php
@@ -18,13 +18,13 @@ use Xabbuh\XApi\Model\StatementObject;
 
 class ActivitySpec extends ObjectBehavior
 {
-    function it_is_an_xapi_object()
+    public function it_is_an_xapi_object()
     {
         $this->beConstructedWith(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->shouldHaveType(StatementObject::class);
     }
 
-    function it_is_equal_with_other_activity_if_ids_are_equal_and_definitions_are_missing()
+    public function it_is_equal_with_other_activity_if_ids_are_equal_and_definitions_are_missing()
     {
         $this->beConstructedWith(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
 

--- a/spec/AgentProfileDocumentSpec.php
+++ b/spec/AgentProfileDocumentSpec.php
@@ -21,20 +21,20 @@ use Xabbuh\XApi\Model\IRI;
 
 class AgentProfileDocumentSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->beConstructedWith(new AgentProfile('id', new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')))), new DocumentData(array(
+        $this->beConstructedWith(new AgentProfile('id', new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')))), new DocumentData([
             'x' => 'foo',
             'y' => 'bar',
-        )));
+        ]));
     }
 
-    function it_is_a_document()
+    public function it_is_a_document()
     {
         $this->shouldHaveType(Document::class);
     }
 
-    function its_data_can_be_read()
+    public function its_data_can_be_read()
     {
         $this->offsetExists('x')->shouldReturn(true);
         $this->offsetGet('x')->shouldReturn('foo');
@@ -43,12 +43,12 @@ class AgentProfileDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
-    function it_throws_exception_when_not_existing_data_is_being_read()
+    public function it_throws_exception_when_not_existing_data_is_being_read()
     {
         $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
     }
 
-    function its_data_cannot_be_manipulated()
+    public function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetUnset('x');

--- a/spec/AgentSpec.php
+++ b/spec/AgentSpec.php
@@ -20,14 +20,14 @@ use Xabbuh\XApi\Model\IRI;
 
 class AgentSpec extends ObjectBehavior
 {
-    function it_is_an_actor()
+    public function it_is_an_actor()
     {
         $iri = InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'));
         $this->beConstructedWith($iri);
         $this->shouldHaveType(Actor::class);
     }
 
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $iri = InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'));
         $this->beConstructedWith($iri, 'test');
@@ -36,14 +36,14 @@ class AgentSpec extends ObjectBehavior
         $this->getName()->shouldReturn('test');
     }
 
-    function it_is_not_equal_to_a_group()
+    public function it_is_not_equal_to_a_group()
     {
         $this->beConstructedWith(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
 
         $this->equals(new Group(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))))->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_an_activity()
+    public function it_is_not_equal_to_an_activity()
     {
         $this->beConstructedWith(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
 

--- a/spec/AttachmentSpec.php
+++ b/spec/AttachmentSpec.php
@@ -10,10 +10,10 @@ use Xabbuh\XApi\Model\LanguageMap;
 
 class AttachmentSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
-        $display = LanguageMap::create(array('en-US' => 'Text attachment'));
-        $description = LanguageMap::create(array('en-US' => 'Text attachment description'));
+        $display = LanguageMap::create(['en-US' => 'Text attachment']);
+        $description = LanguageMap::create(['en-US' => 'Text attachment description']);
 
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
@@ -36,28 +36,28 @@ class AttachmentSpec extends ObjectBehavior
         $this->getContent()->shouldReturn('some text content');
     }
 
-    function it_throws_an_exception_when_an_attachment_does_not_contain_a_file_url_or_raw_content()
+    public function it_throws_an_exception_when_an_attachment_does_not_contain_a_file_url_or_raw_content()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment'))
+            LanguageMap::create(['en-US' => 'Text attachment'])
         );
 
         $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
     }
 
-    function it_is_not_equal_to_other_attachment_if_usage_types_differ()
+    public function it_is_not_equal_to_other_attachment_if_usage_types_differ()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -66,23 +66,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_content_types_differ()
+    public function it_is_not_equal_to_other_attachment_if_content_types_differ()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -91,23 +91,23 @@ class AttachmentSpec extends ObjectBehavior
             'application/json',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_lengths_differ()
+    public function it_is_not_equal_to_other_attachment_if_lengths_differ()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -116,23 +116,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             65556,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_sha2_hashes_differ()
+    public function it_is_not_equal_to_other_attachment_if_sha2_hashes_differ()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -141,23 +141,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'd14f1580a2cebb6f8d4a8a2fc0d13c67f970e84f8d15677a93ae95c9080df899',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_displays_differ()
+    public function it_is_not_equal_to_other_attachment_if_displays_differ()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -166,23 +166,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'JSON attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'JSON attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_only_this_attachment_has_a_description()
+    public function it_is_not_equal_to_other_attachment_if_only_this_attachment_has_a_description()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -191,7 +191,7 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
             null,
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
@@ -199,14 +199,14 @@ class AttachmentSpec extends ObjectBehavior
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_only_the_other_attachment_has_a_description()
+    public function it_is_not_equal_to_other_attachment_if_only_the_other_attachment_has_a_description()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
             null,
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
@@ -216,23 +216,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_descriptions_are_not_equal()
+    public function it_is_not_equal_to_other_attachment_if_descriptions_are_not_equal()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -241,23 +241,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-GB' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-GB' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_only_this_attachment_has_a_file_url()
+    public function it_is_not_equal_to_other_attachment_if_only_this_attachment_has_a_file_url()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -266,50 +266,50 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
-            null,
-            'some text content'
-        );
-
-        $this->equals($attachment)->shouldReturn(false);
-    }
-
-    function it_is_not_equal_to_other_attachment_if_only_the_other_attachment_has_a_file_url()
-    {
-        $this->beConstructedWith(
-            IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
-            'text/plain',
-            18,
-            'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             null,
             'some text content'
         );
 
-        $attachment = new Attachment(
-            IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
-            'text/plain',
-            18,
-            'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
-            IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
-        );
-
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_attachment_if_file_urls_are_not_equal()
+    public function it_is_not_equal_to_other_attachment_if_only_the_other_attachment_has_a_file_url()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
+            null,
+            'some text content'
+        );
+
+        $attachment = new Attachment(
+            IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
+            'text/plain',
+            18,
+            'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
+            IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
+        );
+
+        $this->equals($attachment)->shouldReturn(false);
+    }
+
+    public function it_is_not_equal_to_other_attachment_if_file_urls_are_not_equal()
+    {
+        $this->beConstructedWith(
+            IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
+            'text/plain',
+            18,
+            'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/signature')
         );
 
@@ -318,23 +318,23 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/certificate')
         );
 
         $this->equals($attachment)->shouldReturn(false);
     }
 
-    function it_is_equal_to_other_attachment_if_all_properties_are_equal()
+    public function it_is_equal_to_other_attachment_if_all_properties_are_equal()
     {
         $this->beConstructedWith(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 
@@ -343,8 +343,8 @@ class AttachmentSpec extends ObjectBehavior
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
 

--- a/spec/ContextActivitiesSpec.php
+++ b/spec/ContextActivitiesSpec.php
@@ -36,7 +36,7 @@ class ContextActivitiesSpec extends ObjectBehavior
     {
         $activity = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
 
-        $this->beConstructedWith(array($activity));
+        $this->beConstructedWith([$activity]);
 
         $contextActivities = $this->withoutParentActivities();
 
@@ -70,7 +70,7 @@ class ContextActivitiesSpec extends ObjectBehavior
     {
         $activity = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
 
-        $this->beConstructedWith(null, array($activity));
+        $this->beConstructedWith(null, [$activity]);
 
         $contextActivities = $this->withoutGroupingActivities();
 
@@ -104,7 +104,7 @@ class ContextActivitiesSpec extends ObjectBehavior
     {
         $activity = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
 
-        $this->beConstructedWith(null, null, array($activity));
+        $this->beConstructedWith(null, null, [$activity]);
 
         $contextActivities = $this->withoutCategoryActivities();
 
@@ -138,7 +138,7 @@ class ContextActivitiesSpec extends ObjectBehavior
     {
         $activity = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
 
-        $this->beConstructedWith(null, null, null, array($activity));
+        $this->beConstructedWith(null, null, null, [$activity]);
 
         $contextActivities = $this->withoutOtherActivities();
 

--- a/spec/ContextSpec.php
+++ b/spec/ContextSpec.php
@@ -134,21 +134,21 @@ class ContextSpec extends ObjectBehavior
         $context->getExtensions()->shouldReturn($extensions);
     }
 
-    function it_is_not_equal_to_other_context_if_only_this_context_has_a_team()
+    public function it_is_not_equal_to_other_context_if_only_this_context_has_a_team()
     {
         $context = $this->withTeam(new Group());
 
         $context->equals(new Context())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_only_the_other_context_has_a_team()
+    public function it_is_not_equal_to_other_context_if_only_the_other_context_has_a_team()
     {
         $otherContext = $this->withTeam(new Group());
 
         $this->equals($otherContext)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_teams_are_not_equal()
+    public function it_is_not_equal_to_other_context_if_teams_are_not_equal()
     {
         $context = $this->withTeam(new Group());
 
@@ -158,21 +158,21 @@ class ContextSpec extends ObjectBehavior
         $context->equals($otherContext)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_only_this_context_has_a_statement_reference()
+    public function it_is_not_equal_to_other_context_if_only_this_context_has_a_statement_reference()
     {
         $context = $this->withStatement(new StatementReference(StatementId::fromString('16fd2706-8baf-433b-82eb-8c7fada847da')));
 
         $context->equals(new Context())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_only_the_other_context_has_a_statement_reference()
+    public function it_is_not_equal_to_other_context_if_only_the_other_context_has_a_statement_reference()
     {
         $otherContext = $this->withStatement(new StatementReference(StatementId::fromString('16fd2706-8baf-433b-82eb-8c7fada847da')));
 
         $this->equals($otherContext)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_statement_references_are_not_equal()
+    public function it_is_not_equal_to_other_context_if_statement_references_are_not_equal()
     {
         $context = $this->withStatement(new StatementReference(StatementId::fromString('16fd2706-8baf-433b-82eb-8c7fada847da')));
 
@@ -182,21 +182,21 @@ class ContextSpec extends ObjectBehavior
         $context->equals($otherContext)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_only_this_context_has_extensions()
+    public function it_is_not_equal_to_other_context_if_only_this_context_has_extensions()
     {
         $context = $this->withExtensions(new Extensions());
 
         $context->equals(new Context())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_only_the_other_context_has_extensions()
+    public function it_is_not_equal_to_other_context_if_only_the_other_context_has_extensions()
     {
         $otherContext = $this->withExtensions(new Extensions());
 
         $this->equals($otherContext)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_context_if_extensions_are_not_equal()
+    public function it_is_not_equal_to_other_context_if_extensions_are_not_equal()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/subject'), 'Conformance Testing');

--- a/spec/DefinitionSpec.php
+++ b/spec/DefinitionSpec.php
@@ -20,10 +20,10 @@ use Xabbuh\XApi\Model\LanguageMap;
 
 class DefinitionSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
-        $name = LanguageMap::create(array('en-US' => 'test'));
-        $description = LanguageMap::create(array('en-US' => 'test'));
+        $name = LanguageMap::create(['en-US' => 'test']);
+        $description = LanguageMap::create(['en-US' => 'test']);
         $this->beConstructedWith(
             $name,
             $description,
@@ -37,7 +37,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->getMoreInfo()->equals(IRL::fromString('https://github.com/adlnet/xAPI_LRS_Test'))->shouldReturn(true);
     }
 
-    function it_can_be_empty()
+    public function it_can_be_empty()
     {
         $this->getName()->shouldReturn(null);
         $this->getDescription()->shouldReturn(null);
@@ -107,24 +107,24 @@ class DefinitionSpec extends ObjectBehavior
         $definition->getExtensions()->shouldReturn($extensions);
     }
 
-    function it_is_different_when_names_are_omitted_and_other_definition_contains_an_empty_list_of_names()
+    public function it_is_different_when_names_are_omitted_and_other_definition_contains_an_empty_list_of_names()
     {
         $this->equals(new Definition(new LanguageMap()))->shouldReturn(false);
     }
 
-    function it_is_different_when_descriptions_are_omitted_and_other_definition_contains_an_empty_list_of_descriptions()
+    public function it_is_different_when_descriptions_are_omitted_and_other_definition_contains_an_empty_list_of_descriptions()
     {
         $this->equals(new Definition(null, new LanguageMap()))->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_this_definition_has_a_type()
+    public function it_is_not_equal_to_other_definition_if_only_this_definition_has_a_type()
     {
         $this->beConstructedWith(null, null, IRI::fromString('http://id.tincanapi.com/activitytype/unit-test'));
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_a_type()
+    public function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_a_type()
     {
         $this->beConstructedWith();
 
@@ -134,7 +134,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_types_are_not_equal()
+    public function it_is_not_equal_to_other_definition_if_types_are_not_equal()
     {
         $this->beConstructedWith(null, null, IRI::fromString('http://id.tincanapi.com/activitytype/unit-test'));
 
@@ -144,14 +144,14 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_this_definition_has_more_info()
+    public function it_is_not_equal_to_other_definition_if_only_this_definition_has_more_info()
     {
         $this->beConstructedWith(null, null, null, IRL::fromString('https://github.com/adlnet/xAPI_LRS_Test'));
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_more_info()
+    public function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_more_info()
     {
         $this->beConstructedWith();
 
@@ -161,7 +161,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_more_infos_are_not_equal()
+    public function it_is_not_equal_to_other_definition_if_more_infos_are_not_equal()
     {
         $this->beConstructedWith(null, null, null, IRL::fromString('https://github.com/adlnet/xAPI_LRS_Test'));
 
@@ -171,7 +171,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_this_definition_has_extensions()
+    public function it_is_not_equal_to_other_definition_if_only_this_definition_has_extensions()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
@@ -180,7 +180,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_extensions()
+    public function it_is_not_equal_to_other_definition_if_only_the_other_definition_has_extensions()
     {
         $this->beConstructedWith();
 
@@ -192,7 +192,7 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_definition_if_extensions_are_not_equal()
+    public function it_is_not_equal_to_other_definition_if_extensions_are_not_equal()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/subject'), 'Conformance Testing');
@@ -206,13 +206,13 @@ class DefinitionSpec extends ObjectBehavior
         $this->equals($definition)->shouldReturn(false);
     }
 
-    function it_is_equal_to_other_definition_if_properties_are_equal()
+    public function it_is_equal_to_other_definition_if_properties_are_equal()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
         $this->beConstructedWith(
-            LanguageMap::create(array('en-US' => 'test')),
-            LanguageMap::create(array('en-US' => 'test')),
+            LanguageMap::create(['en-US' => 'test']),
+            LanguageMap::create(['en-US' => 'test']),
             IRI::fromString('http://id.tincanapi.com/activitytype/unit-test'),
             IRL::fromString('https://github.com/adlnet/xAPI_LRS_Test'),
             new Extensions($extensions)
@@ -221,8 +221,8 @@ class DefinitionSpec extends ObjectBehavior
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
         $definition = $this->createEmptyDefinition();
-        $definition = $definition->withName(LanguageMap::create(array('en-US' => 'test')));
-        $definition = $definition->withDescription(LanguageMap::create(array('en-US' => 'test')));
+        $definition = $definition->withName(LanguageMap::create(['en-US' => 'test']));
+        $definition = $definition->withDescription(LanguageMap::create(['en-US' => 'test']));
         $definition = $definition->withType(IRI::fromString('http://id.tincanapi.com/activitytype/unit-test'));
         $definition = $definition->withMoreInfo(IRL::fromString('https://github.com/adlnet/xAPI_LRS_Test'));
         $definition = $definition->withExtensions(new Extensions($extensions));

--- a/spec/ExtensionsSpec.php
+++ b/spec/ExtensionsSpec.php
@@ -9,21 +9,21 @@ use Xabbuh\XApi\Model\IRL;
 
 class ExtensionsSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
         $this->beConstructedWith($extensions);
     }
 
-    function its_extensions_can_be_read()
+    public function its_extensions_can_be_read()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
-        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), array(
+        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), [
             'model' => 'RGB',
             'value' => '#FFFFFF',
-        ));
+        ]);
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/starting-position'), 1);
         $this->beConstructedWith($extensions);
 
@@ -31,10 +31,10 @@ class ExtensionsSpec extends ObjectBehavior
         $this->offsetGet(IRI::fromString('http://id.tincanapi.com/extension/topic'))->shouldReturn('Conformance Testing');
 
         $this->offsetExists(IRI::fromString('http://id.tincanapi.com/extension/color'))->shouldReturn(true);
-        $this->offsetGet(IRI::fromString('http://id.tincanapi.com/extension/color'))->shouldReturn(array(
+        $this->offsetGet(IRI::fromString('http://id.tincanapi.com/extension/color'))->shouldReturn([
             'model' => 'RGB',
             'value' => '#FFFFFF',
-        ));
+        ]);
 
         $this->offsetExists(IRI::fromString('http://id.tincanapi.com/extension/starting-position'))->shouldReturn(true);
         $this->offsetGet(IRI::fromString('http://id.tincanapi.com/extension/starting-position'))->shouldReturn(1);
@@ -44,7 +44,7 @@ class ExtensionsSpec extends ObjectBehavior
         $returnedExtensions->count()->shouldReturn(3);
     }
 
-    function it_throws_exception_when_keys_are_passed_that_are_not_iri_instances_during_instantiation()
+    public function it_throws_exception_when_keys_are_passed_that_are_not_iri_instances_during_instantiation()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRL::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
@@ -52,24 +52,24 @@ class ExtensionsSpec extends ObjectBehavior
         $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
     }
 
-    function it_throws_exception_when_keys_are_passed_that_are_not_iri_instances()
+    public function it_throws_exception_when_keys_are_passed_that_are_not_iri_instances()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('offsetExists', array('http://id.tincanapi.com/extension/topic'));
-        $this->shouldThrow('\InvalidArgumentException')->during('offsetGet', array('http://id.tincanapi.com/extension/topic'));
+        $this->shouldThrow('\InvalidArgumentException')->during('offsetExists', ['http://id.tincanapi.com/extension/topic']);
+        $this->shouldThrow('\InvalidArgumentException')->during('offsetGet', ['http://id.tincanapi.com/extension/topic']);
     }
 
-    function it_throws_exception_when_not_existing_extension_is_being_read()
+    public function it_throws_exception_when_not_existing_extension_is_being_read()
     {
         $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet(IRI::fromString('z'));
     }
 
-    function its_extensions_cannot_be_manipulated()
+    public function its_extensions_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet(IRI::fromString('z'), 'baz');
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetUnset(IRI::fromString('x'));
     }
 
-    function its_not_equal_to_other_extensions_with_a_different_number_of_entries()
+    public function its_not_equal_to_other_extensions_with_a_different_number_of_entries()
     {
         $this->equals(new Extensions())->shouldReturn(false);
 
@@ -79,7 +79,7 @@ class ExtensionsSpec extends ObjectBehavior
         $this->equals(new Extensions($extensions))->shouldReturn(false);
     }
 
-    function its_not_equal_to_other_extensions_if_extension_keys_differ()
+    public function its_not_equal_to_other_extensions_if_extension_keys_differ()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/subject'), 'Conformance Testing');
@@ -87,7 +87,7 @@ class ExtensionsSpec extends ObjectBehavior
         $this->equals(new Extensions($extensions))->shouldReturn(false);
     }
 
-    function its_not_equal_to_other_extensions_if_extension_values_differ()
+    public function its_not_equal_to_other_extensions_if_extension_values_differ()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Tests');
@@ -95,24 +95,24 @@ class ExtensionsSpec extends ObjectBehavior
         $this->equals(new Extensions($extensions))->shouldReturn(false);
     }
 
-    function its_equal_to_other_extensions_even_if_extension_names_are_in_different_order()
+    public function its_equal_to_other_extensions_even_if_extension_names_are_in_different_order()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
-        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), array(
+        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), [
             'model' => 'RGB',
             'value' => '#FFFFFF',
-        ));
+        ]);
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/starting-position'), 1);
 
         $this->beConstructedWith($extensions);
 
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/starting-position'), 1);
-        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), array(
+        $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/color'), [
             'model' => 'RGB',
             'value' => '#FFFFFF',
-        ));
+        ]);
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');
 
         $this->equals(new Extensions($extensions))->shouldReturn(true);

--- a/spec/GroupSpec.php
+++ b/spec/GroupSpec.php
@@ -20,22 +20,22 @@ use Xabbuh\XApi\Model\IRI;
 
 class GroupSpec extends ObjectBehavior
 {
-    function it_can_be_initialized_without_an_inverse_functional_identifier()
+    public function it_can_be_initialized_without_an_inverse_functional_identifier()
     {
         $this->beConstructedWith(null, 'anonymous group');
         $this->shouldBeAnInstanceOf(Group::class);
     }
 
-    function it_is_an_actor()
+    public function it_is_an_actor()
     {
         $this->beConstructedWith(null, 'test');
         $this->shouldHaveType(Actor::class);
     }
 
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $iri = InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'));
-        $members = array(new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))));
+        $members = [new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')))];
         $this->beConstructedWith($iri, 'test', $members);
 
         $this->getInverseFunctionalIdentifier()->shouldReturn($iri);

--- a/spec/Interaction/ChoiceInteractionDefinitionSpec.php
+++ b/spec/Interaction/ChoiceInteractionDefinitionSpec.php
@@ -18,7 +18,7 @@ class ChoiceInteractionDefinitionSpec extends InteractionDefinitionSpec
 {
     public function it_returns_a_new_instance_with_choices()
     {
-        $choices = array(new InteractionComponent('test'));
+        $choices = [new InteractionComponent('test')];
         $interaction = $this->withChoices($choices);
 
         $this->getChoices()->shouldBeNull();
@@ -28,47 +28,47 @@ class ChoiceInteractionDefinitionSpec extends InteractionDefinitionSpec
         $interaction->getChoices()->shouldReturn($choices);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_choices()
+    public function it_is_not_equal_if_only_other_interaction_has_choices()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_choices()
+    public function it_is_not_equal_if_only_this_interaction_has_choices()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_choices_differs()
+    public function it_is_not_equal_if_number_of_choices_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_choices_differ()
+    public function it_is_not_equal_if_choices_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withChoices([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_choices_are_equal()
+    public function it_is_equal_if_choices_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/Interaction/InteractionComponentSpec.php
+++ b/spec/Interaction/InteractionComponentSpec.php
@@ -17,18 +17,18 @@ use Xabbuh\XApi\Model\LanguageMap;
 
 class InteractionComponentSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
-        $description = LanguageMap::create(array('en-US' => 'test'));
+        $description = LanguageMap::create(['en-US' => 'test']);
         $this->beConstructedWith('test', $description);
 
         $this->getId()->shouldReturn('test');
         $this->getDescription()->shouldReturn($description);
     }
 
-    function it_is_not_equal_with_other_interaction_component_if_ids_differ()
+    public function it_is_not_equal_with_other_interaction_component_if_ids_differ()
     {
-        $description = LanguageMap::create(array('en-US' => 'test'));
+        $description = LanguageMap::create(['en-US' => 'test']);
         $this->beConstructedWith('test', $description);
 
         $interactionComponent = new InteractionComponent('Test', $description);
@@ -36,43 +36,43 @@ class InteractionComponentSpec extends ObjectBehavior
         $this->equals($interactionComponent)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_interaction_component_if_descriptions_differ()
+    public function it_is_not_equal_with_other_interaction_component_if_descriptions_differ()
     {
-        $this->beConstructedWith('test', LanguageMap::create(array('en-US' => 'test')));
+        $this->beConstructedWith('test', LanguageMap::create(['en-US' => 'test']));
 
-        $interactionComponent = new InteractionComponent('test', LanguageMap::create(array('en-GB' => 'test')));
+        $interactionComponent = new InteractionComponent('test', LanguageMap::create(['en-GB' => 'test']));
 
         $this->equals($interactionComponent)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_interaction_component_if_other_interaction_component_does_not_have_a_description()
+    public function it_is_not_equal_with_other_interaction_component_if_other_interaction_component_does_not_have_a_description()
     {
-        $this->beConstructedWith('test', LanguageMap::create(array('en-US' => 'test')));
+        $this->beConstructedWith('test', LanguageMap::create(['en-US' => 'test']));
 
         $interactionComponent = new InteractionComponent('test');
 
         $this->equals($interactionComponent)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_interaction_component_if_only_the_other_interaction_component_does_have_a_description()
+    public function it_is_not_equal_with_other_interaction_component_if_only_the_other_interaction_component_does_have_a_description()
     {
         $this->beConstructedWith('test');
 
-        $interactionComponent = new InteractionComponent('test', LanguageMap::create(array('en-US' => 'test')));
+        $interactionComponent = new InteractionComponent('test', LanguageMap::create(['en-US' => 'test']));
 
         $this->equals($interactionComponent)->shouldReturn(false);
     }
 
-    function it_is_equal_with_other_interaction_component_if_ids_and_descriptions_are_equal()
+    public function it_is_equal_with_other_interaction_component_if_ids_and_descriptions_are_equal()
     {
-        $this->beConstructedWith('test', LanguageMap::create(array('en-US' => 'test')));
+        $this->beConstructedWith('test', LanguageMap::create(['en-US' => 'test']));
 
-        $interactionComponent = new InteractionComponent('test', LanguageMap::create(array('en-US' => 'test')));
+        $interactionComponent = new InteractionComponent('test', LanguageMap::create(['en-US' => 'test']));
 
         $this->equals($interactionComponent)->shouldReturn(true);
     }
 
-    function it_is_equal_with_other_interaction_component_if_ids_are_equal_and_descriptions_are_not_present()
+    public function it_is_equal_with_other_interaction_component_if_ids_are_equal_and_descriptions_are_not_present()
     {
         $this->beConstructedWith('test');
 

--- a/spec/Interaction/InteractionDefinitionSpec.php
+++ b/spec/Interaction/InteractionDefinitionSpec.php
@@ -17,62 +17,62 @@ use Xabbuh\XApi\Model\Interaction\InteractionDefinition;
 
 abstract class InteractionDefinitionSpec extends DefinitionSpec
 {
-    function it_is_a_definition()
+    public function it_is_a_definition()
     {
         $this->shouldHaveType(Definition::class);
     }
 
-    function it_is_an_interaction()
+    public function it_is_an_interaction()
     {
         $this->shouldHaveType(InteractionDefinition::class);
     }
 
-    function it_is_not_equal_to_generic_definition()
+    public function it_is_not_equal_to_generic_definition()
     {
         $this->equals(new Definition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_correct_responses_pattern()
+    public function it_is_not_equal_if_only_other_interaction_has_correct_responses_pattern()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withCorrectResponsesPattern(array('test'));
+        $interaction = $interaction->withCorrectResponsesPattern(['test']);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_correct_responses_pattern()
+    public function it_is_not_equal_if_only_this_interaction_has_correct_responses_pattern()
     {
-        $this->beConstructedWith(null, null, null, null, null, array('test'));
+        $this->beConstructedWith(null, null, null, null, null, ['test']);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_correct_responses_pattern_differs()
+    public function it_is_not_equal_if_number_of_correct_responses_pattern_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, array('test'));
+        $this->beConstructedWith(null, null, null, null, null, ['test']);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withCorrectResponsesPattern(array('test', 'foo'));
+        $interaction = $interaction->withCorrectResponsesPattern(['test', 'foo']);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_correct_responses_pattern_values_differ()
+    public function it_is_not_equal_if_correct_responses_pattern_values_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, array('foo'));
+        $this->beConstructedWith(null, null, null, null, null, ['foo']);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withCorrectResponsesPattern(array('bar'));
+        $interaction = $interaction->withCorrectResponsesPattern(['bar']);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_correct_responses_pattern_values_are_equal()
+    public function it_is_equal_if_correct_responses_pattern_values_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, array('test'));
+        $this->beConstructedWith(null, null, null, null, null, ['test']);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withCorrectResponsesPattern(array('test'));
+        $interaction = $interaction->withCorrectResponsesPattern(['test']);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/Interaction/LikertInteractionDefinitionSpec.php
+++ b/spec/Interaction/LikertInteractionDefinitionSpec.php
@@ -18,7 +18,7 @@ class LikertInteractionDefinitionSpec extends InteractionDefinitionSpec
 {
     public function it_returns_a_new_instance_with_scale()
     {
-        $scale = array(new InteractionComponent('test'));
+        $scale = [new InteractionComponent('test')];
         $interaction = $this->withScale($scale);
 
         $this->getScale()->shouldBeNull();
@@ -28,47 +28,47 @@ class LikertInteractionDefinitionSpec extends InteractionDefinitionSpec
         $interaction->getScale()->shouldReturn($scale);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_scale()
+    public function it_is_not_equal_if_only_other_interaction_has_scale()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withScale(array(new InteractionComponent('test')));
+        $interaction = $interaction->withScale([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_scale()
+    public function it_is_not_equal_if_only_this_interaction_has_scale()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_scale_differs()
+    public function it_is_not_equal_if_number_of_scale_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withScale(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withScale([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_scale_differ()
+    public function it_is_not_equal_if_scale_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withScale(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withScale([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_scales_are_equal()
+    public function it_is_equal_if_scales_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withScale(array(new InteractionComponent('test')));
+        $interaction = $interaction->withScale([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/Interaction/MatchingInteractionDefinitionSpec.php
+++ b/spec/Interaction/MatchingInteractionDefinitionSpec.php
@@ -18,7 +18,7 @@ class MatchingInteractionDefinitionSpec extends InteractionDefinitionSpec
 {
     public function it_returns_a_new_instance_with_source()
     {
-        $source = array(new InteractionComponent('test'));
+        $source = [new InteractionComponent('test')];
         $interaction = $this->withSource($source);
 
         $this->getSource()->shouldBeNull();
@@ -30,7 +30,7 @@ class MatchingInteractionDefinitionSpec extends InteractionDefinitionSpec
 
     public function it_returns_a_new_instance_with_target()
     {
-        $target = array(new InteractionComponent('test'));
+        $target = [new InteractionComponent('test')];
         $interaction = $this->withTarget($target);
 
         $this->getTarget()->shouldBeNull();
@@ -40,92 +40,92 @@ class MatchingInteractionDefinitionSpec extends InteractionDefinitionSpec
         $interaction->getTarget()->shouldReturn($target);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_source()
+    public function it_is_not_equal_if_only_other_interaction_has_source()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSource(array(new InteractionComponent('test')));
+        $interaction = $interaction->withSource([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_source()
+    public function it_is_not_equal_if_only_this_interaction_has_source()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_source_differs()
+    public function it_is_not_equal_if_number_of_source_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSource(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withSource([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_source_differ()
+    public function it_is_not_equal_if_source_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSource(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withSource([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_sources_are_equal()
+    public function it_is_equal_if_sources_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSource(array(new InteractionComponent('test')));
+        $interaction = $interaction->withSource([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_target()
+    public function it_is_not_equal_if_only_other_interaction_has_target()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withTarget(array(new InteractionComponent('test')));
+        $interaction = $interaction->withTarget([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_target()
+    public function it_is_not_equal_if_only_this_interaction_has_target()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_target_differs()
+    public function it_is_not_equal_if_number_of_target_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withTarget(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withTarget([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_target_differ()
+    public function it_is_not_equal_if_target_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withTarget(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withTarget([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_targets_are_equal()
+    public function it_is_equal_if_targets_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withTarget(array(new InteractionComponent('test')));
+        $interaction = $interaction->withTarget([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/Interaction/PerformanceInteractionDefinitionSpec.php
+++ b/spec/Interaction/PerformanceInteractionDefinitionSpec.php
@@ -18,7 +18,7 @@ class PerformanceInteractionDefinitionSpec extends InteractionDefinitionSpec
 {
     public function it_returns_a_new_instance_with_steps()
     {
-        $steps = array(new InteractionComponent('test'));
+        $steps = [new InteractionComponent('test')];
         $interaction = $this->withSteps($steps);
 
         $this->getSteps()->shouldBeNull();
@@ -28,47 +28,47 @@ class PerformanceInteractionDefinitionSpec extends InteractionDefinitionSpec
         $interaction->getSteps()->shouldReturn($steps);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_steps()
+    public function it_is_not_equal_if_only_other_interaction_has_steps()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSteps(array(new InteractionComponent('test')));
+        $interaction = $interaction->withSteps([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_steps()
+    public function it_is_not_equal_if_only_this_interaction_has_steps()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_steps_differs()
+    public function it_is_not_equal_if_number_of_steps_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSteps(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withSteps([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_steps_differ()
+    public function it_is_not_equal_if_steps_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSteps(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withSteps([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_steps_are_equal()
+    public function it_is_equal_if_steps_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withSteps(array(new InteractionComponent('test')));
+        $interaction = $interaction->withSteps([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/Interaction/SequencingInteractionDefinitionSpec.php
+++ b/spec/Interaction/SequencingInteractionDefinitionSpec.php
@@ -18,7 +18,7 @@ class SequencingInteractionDefinitionSpec extends InteractionDefinitionSpec
 {
     public function it_returns_a_new_instance_with_choices()
     {
-        $choices = array(new InteractionComponent('test'));
+        $choices = [new InteractionComponent('test')];
         $interaction = $this->withChoices($choices);
 
         $this->getChoices()->shouldBeNull();
@@ -28,47 +28,47 @@ class SequencingInteractionDefinitionSpec extends InteractionDefinitionSpec
         $interaction->getChoices()->shouldReturn($choices);
     }
 
-    function it_is_not_equal_if_only_other_interaction_has_choices()
+    public function it_is_not_equal_if_only_other_interaction_has_choices()
     {
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_only_this_interaction_has_choices()
+    public function it_is_not_equal_if_only_this_interaction_has_choices()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $this->equals($this->createEmptyDefinition())->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_number_of_choices_differs()
+    public function it_is_not_equal_if_number_of_choices_differs()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test'), new InteractionComponent('foo')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test'), new InteractionComponent('foo')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_not_equal_if_choices_differ()
+    public function it_is_not_equal_if_choices_differ()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('foo')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('foo')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('bar')));
+        $interaction = $interaction->withChoices([new InteractionComponent('bar')]);
 
         $this->equals($interaction)->shouldReturn(false);
     }
 
-    function it_is_equal_if_choices_are_equal()
+    public function it_is_equal_if_choices_are_equal()
     {
-        $this->beConstructedWith(null, null, null, null, null, null, array(new InteractionComponent('test')));
+        $this->beConstructedWith(null, null, null, null, null, null, [new InteractionComponent('test')]);
 
         $interaction = $this->createEmptyDefinition();
-        $interaction = $interaction->withChoices(array(new InteractionComponent('test')));
+        $interaction = $interaction->withChoices([new InteractionComponent('test')]);
 
         $this->equals($interaction)->shouldReturn(true);
     }

--- a/spec/InverseFunctionalIdentifierSpec.php
+++ b/spec/InverseFunctionalIdentifierSpec.php
@@ -19,12 +19,14 @@ use Xabbuh\XApi\Model\IRL;
 
 class InverseFunctionalIdentifierSpec extends ObjectBehavior
 {
-    function it_can_be_built_with_an_mbox()
+    public function it_can_be_built_with_an_mbox()
     {
         $iri = IRI::fromString('mailto:conformancetest@tincanapi.com');
         $this->beConstructedThrough(
-            array(InverseFunctionalIdentifier::class, 'withMbox'),
-            array($iri)
+            function (\Xabbuh\XApi\Model\IRI $mbox): \Xabbuh\XApi\Model\InverseFunctionalIdentifier {
+                return InverseFunctionalIdentifier::withMbox($mbox);
+            },
+            [$iri]
         );
 
         $this->getMbox()->shouldReturn($iri);
@@ -33,11 +35,13 @@ class InverseFunctionalIdentifierSpec extends ObjectBehavior
         $this->getAccount()->shouldReturn(null);
     }
 
-    function it_can_be_built_with_an_mbox_sha1_sum()
+    public function it_can_be_built_with_an_mbox_sha1_sum()
     {
         $this->beConstructedThrough(
-            array(InverseFunctionalIdentifier::class, 'withMboxSha1Sum'),
-            array('db77b9104b531ecbb0b967f6942549d0ba80fda1')
+            function (string $mboxSha1Sum): \Xabbuh\XApi\Model\InverseFunctionalIdentifier {
+                return InverseFunctionalIdentifier::withMboxSha1Sum($mboxSha1Sum);
+            },
+            ['db77b9104b531ecbb0b967f6942549d0ba80fda1']
         );
 
         $this->getMbox()->shouldReturn(null);
@@ -46,11 +50,13 @@ class InverseFunctionalIdentifierSpec extends ObjectBehavior
         $this->getAccount()->shouldReturn(null);
     }
 
-    function it_can_be_built_with_an_openid()
+    public function it_can_be_built_with_an_openid()
     {
         $this->beConstructedThrough(
-            array(InverseFunctionalIdentifier::class, 'withOpenId'),
-            array('http://openid.tincanapi.com')
+            function (string $openId): \Xabbuh\XApi\Model\InverseFunctionalIdentifier {
+                return InverseFunctionalIdentifier::withOpenId($openId);
+            },
+            ['http://openid.tincanapi.com']
         );
 
         $this->getMbox()->shouldReturn(null);
@@ -59,12 +65,14 @@ class InverseFunctionalIdentifierSpec extends ObjectBehavior
         $this->getAccount()->shouldReturn(null);
     }
 
-    function it_can_be_built_with_an_account()
+    public function it_can_be_built_with_an_account()
     {
         $account = new Account('test', IRL::fromString('https://tincanapi.com'));
         $this->beConstructedThrough(
-            array(InverseFunctionalIdentifier::class, 'withAccount'),
-            array($account)
+            function (\Xabbuh\XApi\Model\Account $account): \Xabbuh\XApi\Model\InverseFunctionalIdentifier {
+                return InverseFunctionalIdentifier::withAccount($account);
+            },
+            [$account]
         );
 
         $this->getMbox()->shouldReturn(null);
@@ -73,56 +81,56 @@ class InverseFunctionalIdentifierSpec extends ObjectBehavior
         $this->getAccount()->shouldReturn($account);
     }
 
-    function it_is_equal_when_mboxes_are_equal()
+    public function it_is_equal_when_mboxes_are_equal()
     {
-        $this->beConstructedThrough('withMbox', array(IRI::fromString('mailto:conformancetest@tincanapi.com')));
+        $this->beConstructedThrough('withMbox', [IRI::fromString('mailto:conformancetest@tincanapi.com')]);
 
         $this->equals(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')))->shouldReturn(true);
     }
 
-    function it_is_equal_when_mbox_sha1_sums_are_equal()
+    public function it_is_equal_when_mbox_sha1_sums_are_equal()
     {
-        $this->beConstructedThrough('withMboxSha1Sum', array('db77b9104b531ecbb0b967f6942549d0ba80fda1'));
+        $this->beConstructedThrough('withMboxSha1Sum', ['db77b9104b531ecbb0b967f6942549d0ba80fda1']);
 
         $this->equals(InverseFunctionalIdentifier::withMboxSha1Sum('db77b9104b531ecbb0b967f6942549d0ba80fda1'))->shouldReturn(true);
     }
 
-    function it_is_equal_when_open_ids_are_equal()
+    public function it_is_equal_when_open_ids_are_equal()
     {
-        $this->beConstructedThrough('withOpenId', array('http://openid.tincanapi.com'));
+        $this->beConstructedThrough('withOpenId', ['http://openid.tincanapi.com']);
 
         $this->equals(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'))->shouldReturn(true);
     }
 
-    function it_is_equal_when_accounts_are_equal()
+    public function it_is_equal_when_accounts_are_equal()
     {
-        $this->beConstructedThrough('withAccount', array(new Account('test', IRL::fromString('https://tincanapi.com'))));
+        $this->beConstructedThrough('withAccount', [new Account('test', IRL::fromString('https://tincanapi.com'))]);
 
         $this->equals(InverseFunctionalIdentifier::withAccount(new Account('test', IRL::fromString('https://tincanapi.com'))))->shouldReturn(true);
     }
 
-    function its_mbox_value_can_be_retrieved_as_a_string()
+    public function its_mbox_value_can_be_retrieved_as_a_string()
     {
         $this->beConstructedWithMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'));
 
         $this->__toString()->shouldReturn('mailto:conformancetest@tincanapi.com');
     }
 
-    function its_mbox_sha1_sum_value_can_be_retrieved_as_a_string()
+    public function its_mbox_sha1_sum_value_can_be_retrieved_as_a_string()
     {
         $this->beConstructedWithMboxSha1Sum('db77b9104b531ecbb0b967f6942549d0ba80fda1');
 
         $this->__toString()->shouldReturn('db77b9104b531ecbb0b967f6942549d0ba80fda1');
     }
 
-    function its_open_id_value_can_be_retrieved_as_a_string()
+    public function its_open_id_value_can_be_retrieved_as_a_string()
     {
         $this->beConstructedWithOpenId('http://openid.tincanapi.com');
 
         $this->__toString()->shouldReturn('http://openid.tincanapi.com');
     }
 
-    function its_account_value_can_be_retrieved_as_a_string()
+    public function its_account_value_can_be_retrieved_as_a_string()
     {
         $this->beConstructedWithAccount(new Account('test', IRL::fromString('https://tincanapi.com')));
 

--- a/spec/LanguageMapSpec.php
+++ b/spec/LanguageMapSpec.php
@@ -7,33 +7,33 @@ use Xabbuh\XApi\Model\LanguageMap;
 
 class LanguageMapSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
-        $this->beConstructedThrough('create', array(array(
+        $this->beConstructedThrough('create', [[
             'de-DE' => 'teilgenommen',
             'en-GB' => 'attended',
-        )));
+        ]]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(LanguageMap::class);
     }
 
-    function it_can_be_created_with_an_existing_array_map()
+    public function it_can_be_created_with_an_existing_array_map()
     {
-        $this->beConstructedThrough('create', array(array(
+        $this->beConstructedThrough('create', [[
             'de-DE' => 'teilgenommen',
             'en-GB' => 'attended',
             'en-US' => 'attended',
-        )));
+        ]]);
 
         $this->offsetGet('de-DE')->shouldReturn('teilgenommen');
         $this->offsetGet('en-GB')->shouldReturn('attended');
         $this->offsetGet('en-US')->shouldReturn('attended');
     }
 
-    function it_returns_a_new_instance_with_an_added_entry()
+    public function it_returns_a_new_instance_with_an_added_entry()
     {
         $languageTag = $this->withEntry('en-US', 'attended');
         $languageTag->offsetExists('en-US')->shouldReturn(true);
@@ -41,7 +41,7 @@ class LanguageMapSpec extends ObjectBehavior
         $this->offsetExists('en-US')->shouldReturn(false);
     }
 
-    function it_returns_a_new_instance_with_a_modified_entry()
+    public function it_returns_a_new_instance_with_a_modified_entry()
     {
         $languageTag = $this->withEntry('en-GB', 'test');
         $languageTag->offsetGet('en-GB')->shouldReturn('test');
@@ -49,7 +49,7 @@ class LanguageMapSpec extends ObjectBehavior
         $this->offsetGet('en-GB')->shouldReturn('attended');
     }
 
-    function its_language_tags_can_be_retrieved()
+    public function its_language_tags_can_be_retrieved()
     {
         $languageTags = $this->languageTags();
         $languageTags->shouldBeArray();
@@ -58,69 +58,69 @@ class LanguageMapSpec extends ObjectBehavior
         $languageTags->shouldContain('en-GB');
     }
 
-    function it_throws_an_exception_when_a_non_existent_language_tag_is_requested()
+    public function it_throws_an_exception_when_a_non_existent_language_tag_is_requested()
     {
-        $this->shouldThrow('\InvalidArgumentException')->during('offsetGet', array('en-US'));
+        $this->shouldThrow('\InvalidArgumentException')->during('offsetGet', ['en-US']);
     }
 
-    function it_can_be_asked_if_a_language_tag_is_known()
+    public function it_can_be_asked_if_a_language_tag_is_known()
     {
         $this->offsetExists('en-GB')->shouldReturn(true);
         $this->offsetExists('en-US')->shouldReturn(false);
     }
 
-    function its_values_cannot_be_modified()
+    public function its_values_cannot_be_modified()
     {
-        $this->shouldThrow('\LogicException')->during('offsetSet', array('en-US', 'attended'));
+        $this->shouldThrow('\LogicException')->during('offsetSet', ['en-US', 'attended']);
     }
 
-    function its_values_cannot_be_removed()
+    public function its_values_cannot_be_removed()
     {
-        $this->shouldThrow('\LogicException')->during('offsetUnset', array('en-US'));
+        $this->shouldThrow('\LogicException')->during('offsetUnset', ['en-US']);
     }
 
-    function it_is_not_equal_with_another_language_map_if_number_of_entries_differ()
+    public function it_is_not_equal_with_another_language_map_if_number_of_entries_differ()
     {
-        $languageMap = LanguageMap::create(array(
+        $languageMap = LanguageMap::create([
             'de-DE' => 'teilgenommen',
             'en-GB' => 'attended',
             'en-US' => 'attended',
-        ));
+        ]);
 
         $this->equals($languageMap)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_another_language_map_if_keys_differ()
+    public function it_is_not_equal_with_another_language_map_if_keys_differ()
     {
-        $languageMap = LanguageMap::create(array(
+        $languageMap = LanguageMap::create([
             'de-DE' => 'teilgenommen',
             'en-US' => 'attended',
-        ));
+        ]);
 
         $this->equals($languageMap)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_another_language_map_if_values_differ()
+    public function it_is_not_equal_with_another_language_map_if_values_differ()
     {
-        $languageMap = LanguageMap::create(array(
+        $languageMap = LanguageMap::create([
             'de-DE' => 'teilgenommen',
             'en-GB' => 'participated',
-        ));
+        ]);
 
         $this->equals($languageMap)->shouldReturn(false);
     }
 
-    function it_is_equal_with_itself()
+    public function it_is_equal_with_itself()
     {
         $this->equals($this)->shouldReturn(true);
     }
 
-    function it_is_equal_with_another_language_map_if_key_value_pairs_are_equal()
+    public function it_is_equal_with_another_language_map_if_key_value_pairs_are_equal()
     {
-        $languageMap = LanguageMap::create(array(
+        $languageMap = LanguageMap::create([
             'en-GB' => 'attended',
             'de-DE' => 'teilgenommen',
-        ));
+        ]);
 
         $this->equals($languageMap)->shouldReturn(true);
     }

--- a/spec/PersonSpec.php
+++ b/spec/PersonSpec.php
@@ -20,100 +20,100 @@ use Xabbuh\XApi\Model\IRL;
 
 class PersonSpec extends ObjectBehavior
 {
-    function it_can_be_built_from_an_array_of_agents()
+    public function it_can_be_built_from_an_array_of_agents()
     {
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))),
             new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
         $this->shouldHaveType('Xabbuh\XApi\Model\Person');
     }
 
-    function it_has_mboxes_from_agents()
+    public function it_has_mboxes_from_agents()
     {
         $mbox = IRI::fromString('mailto:conformancetest@tincanapi.com');
         $mbox2 = IRI::fromString('mailto:conformancetest2@tincanapi.com');
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withMbox($mbox)),
             new Agent(InverseFunctionalIdentifier::withMbox($mbox2)),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
-        $this->getMboxes()->shouldReturn(array(
+        $this->getMboxes()->shouldReturn([
             $mbox,
             $mbox2,
-        ));
+        ]);
     }
 
-    function it_has_mbox_sha_1_sums_from_agents()
+    public function it_has_mbox_sha_1_sums_from_agents()
     {
         $sha1Sum = 'sha1Sum';
         $sha1Sum2 = 'sha1Sum2';
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withMboxSha1Sum($sha1Sum)),
             new Agent(InverseFunctionalIdentifier::withMboxSha1Sum($sha1Sum2)),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
-        $this->getMboxSha1Sums()->shouldReturn(array(
+        $this->getMboxSha1Sums()->shouldReturn([
             $sha1Sum,
             $sha1Sum2,
-        ));
+        ]);
     }
 
-    function it_has_open_ids_from_agents()
+    public function it_has_open_ids_from_agents()
     {
         $openId = 'openId';
         $openId2 = 'openId2';
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withOpenId($openId)),
             new Agent(InverseFunctionalIdentifier::withOpenId($openId2)),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
-        $this->getOpenIds()->shouldReturn(array(
+        $this->getOpenIds()->shouldReturn([
             $openId,
             $openId2,
-        ));
+        ]);
     }
 
-    function it_has_accounts_from_agents()
+    public function it_has_accounts_from_agents()
     {
         $account = new Account('test', IRL::fromString('http://example.com'));
         $account2 = new Account('test2', IRL::fromString('http://example.com'));
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withAccount($account)),
             new Agent(InverseFunctionalIdentifier::withAccount($account2)),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
-        $this->getAccounts()->shouldReturn(array(
+        $this->getAccounts()->shouldReturn([
             $account,
             $account2,
-        ));
+        ]);
     }
 
-    function it_has_names_from_agents()
+    public function it_has_names_from_agents()
     {
         $name = 'name';
         $name2 = 'name2';
-        $agents = array(
+        $agents = [
             new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')), $name),
             new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')), $name2),
-        );
+        ];
 
-        $this->beConstructedThrough('createFromAgents', array($agents));
+        $this->beConstructedThrough('createFromAgents', [$agents]);
 
-        $this->getNames()->shouldReturn(array(
+        $this->getNames()->shouldReturn([
             $name,
             $name2,
-        ));
+        ]);
     }
 }

--- a/spec/ResultSpec.php
+++ b/spec/ResultSpec.php
@@ -19,7 +19,7 @@ use Xabbuh\XApi\Model\Score;
 
 class ResultSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $score = new Score(1);
         $this->beConstructedWith($score, true, true, 'test', 'PT2H');
@@ -31,7 +31,7 @@ class ResultSpec extends ObjectBehavior
         $this->getDuration()->shouldReturn('PT2H');
     }
 
-    function it_can_be_empty()
+    public function it_can_be_empty()
     {
         $this->getScore()->shouldReturn(null);
         $this->getSuccess()->shouldReturn(null);
@@ -42,12 +42,12 @@ class ResultSpec extends ObjectBehavior
         $this->equals(new Result())->shouldReturn(true);
     }
 
-    function it_is_empty_and_is_not_equal_to_a_result_with_a_score()
+    public function it_is_empty_and_is_not_equal_to_a_result_with_a_score()
     {
         $this->equals(new Result(new Score(1)))->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_result_if_not_both_results_have_extensions()
+    public function it_is_not_equal_to_other_result_if_not_both_results_have_extensions()
     {
         $this->beConstructedWith(new Score(1), true, true, 'test', 'PT2H');
 
@@ -58,7 +58,7 @@ class ResultSpec extends ObjectBehavior
             ->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_other_result_if_extensions_are_not_equal()
+    public function it_is_not_equal_to_other_result_if_extensions_are_not_equal()
     {
         $extensions = new \SplObjectStorage();
         $extensions->attach(IRI::fromString('http://id.tincanapi.com/extension/topic'), 'Conformance Testing');

--- a/spec/ScoreSpec.php
+++ b/spec/ScoreSpec.php
@@ -16,7 +16,7 @@ use Xabbuh\XApi\Model\Score;
 
 class ScoreSpec extends ObjectBehavior
 {
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $this->beConstructedWith(1, 100, 0, 100);
 
@@ -26,7 +26,7 @@ class ScoreSpec extends ObjectBehavior
         $this->getMax()->shouldReturn(100);
     }
 
-    function it_can_be_constructed_with_a_scaled_value_only()
+    public function it_can_be_constructed_with_a_scaled_value_only()
     {
         $this->beConstructedWith(1);
 
@@ -36,7 +36,7 @@ class ScoreSpec extends ObjectBehavior
         $this->getMax()->shouldReturn(null);
     }
 
-    function it_can_be_constructed_with_a_raw_value_only()
+    public function it_can_be_constructed_with_a_raw_value_only()
     {
         $this->beConstructedWith(null, 100);
 
@@ -46,7 +46,7 @@ class ScoreSpec extends ObjectBehavior
         $this->getMax()->shouldReturn(null);
     }
 
-    function it_can_be_constructed_with_a_min_value_only()
+    public function it_can_be_constructed_with_a_min_value_only()
     {
         $this->beConstructedWith(null, null, 0);
 
@@ -56,7 +56,7 @@ class ScoreSpec extends ObjectBehavior
         $this->getMax()->shouldReturn(null);
     }
 
-    function it_can_be_constructed_with_a_max_value_only()
+    public function it_can_be_constructed_with_a_max_value_only()
     {
         $this->beConstructedWith(null, null, null, 100);
 
@@ -110,7 +110,7 @@ class ScoreSpec extends ObjectBehavior
         $score->getMax()->shouldReturn(100);
     }
 
-    function it_treats_integers_as_floats_when_comparing()
+    public function it_treats_integers_as_floats_when_comparing()
     {
         $this->beConstructedWith(1, 100, 0, 100);
 

--- a/spec/StateDocumentSpec.php
+++ b/spec/StateDocumentSpec.php
@@ -22,22 +22,22 @@ use Xabbuh\XApi\Model\State;
 
 class StateDocumentSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
         $activity = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $agent = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $this->beConstructedWith(new State($activity, $agent, 'state-id'), new DocumentData(array(
+        $this->beConstructedWith(new State($activity, $agent, 'state-id'), new DocumentData([
             'x' => 'foo',
             'y' => 'bar',
-        )));
+        ]));
     }
 
-    function it_is_a_document()
+    public function it_is_a_document()
     {
         $this->shouldHaveType(Document::class);
     }
 
-    function its_data_can_be_read()
+    public function its_data_can_be_read()
     {
         $this->offsetExists('x')->shouldReturn(true);
         $this->offsetGet('x')->shouldReturn('foo');
@@ -46,12 +46,12 @@ class StateDocumentSpec extends ObjectBehavior
         $this->offsetExists('z')->shouldReturn(false);
     }
 
-    function it_throws_exception_when_not_existing_data_is_being_read()
+    public function it_throws_exception_when_not_existing_data_is_being_read()
     {
         $this->shouldThrow('\InvalidArgumentException')->duringOffsetGet('z');
     }
 
-    function its_data_cannot_be_manipulated()
+    public function its_data_cannot_be_manipulated()
     {
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetSet('z', 'baz');
         $this->shouldThrow('\Xabbuh\XApi\Common\Exception\UnsupportedOperationException')->duringOffsetUnset('x');

--- a/spec/StateDocumentsFilterSpec.php
+++ b/spec/StateDocumentsFilterSpec.php
@@ -16,18 +16,16 @@ use Xabbuh\XApi\Model\Activity;
 use Xabbuh\XApi\Model\Agent;
 use Xabbuh\XApi\Model\InverseFunctionalIdentifier;
 use Xabbuh\XApi\Model\IRI;
-use Xabbuh\XApi\Model\LanguageMap;
-use Xabbuh\XApi\Model\Verb;
 
 class StateDocumentsFilterSpec extends ObjectBehavior
 {
-    function it_does_not_filter_anything_by_default()
+    public function it_does_not_filter_anything_by_default()
     {
         $filter = $this->getFilter();
         $filter->shouldHaveCount(0);
     }
 
-    function it_can_filter_by_activity()
+    public function it_can_filter_by_activity()
     {
         $this->byActivity(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')))->shouldReturn($this);
 
@@ -36,7 +34,7 @@ class StateDocumentsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('activity', 'http://tincanapi.com/conformancetest/activityid');
     }
 
-    function it_can_filter_by_agent()
+    public function it_can_filter_by_agent()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
         $this->byAgent($actor)->shouldReturn($this);
@@ -46,7 +44,7 @@ class StateDocumentsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('agent', $actor);
     }
 
-    function it_can_filter_by_registration()
+    public function it_can_filter_by_registration()
     {
         $this->byRegistration('foo')->shouldReturn($this);
 
@@ -55,7 +53,7 @@ class StateDocumentsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('registration', 'foo');
     }
 
-    function it_can_filter_by_timestamp()
+    public function it_can_filter_by_timestamp()
     {
         $this->since(\DateTime::createFromFormat(\DateTime::ISO8601, '2013-05-18T05:32:34Z'))->shouldReturn($this);
         $this->getFilter()->shouldHaveKeyWithValue('since', '2013-05-18T05:32:34+00:00');

--- a/spec/StatementFactorySpec.php
+++ b/spec/StatementFactorySpec.php
@@ -14,7 +14,7 @@ use Xabbuh\XApi\Model\Verb;
 
 class StatementFactorySpec extends ObjectBehavior
 {
-    function it_creates_a_statement()
+    public function it_creates_a_statement()
     {
         $this->withActor(new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))));
         $this->withVerb(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid')));
@@ -23,7 +23,7 @@ class StatementFactorySpec extends ObjectBehavior
         $this->createStatement()->shouldBeAnInstanceOf('\Xabbuh\Xapi\Model\Statement');
     }
 
-    function it_configures_all_statement_properties()
+    public function it_configures_all_statement_properties()
     {
         $id = StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af');
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
@@ -58,7 +58,7 @@ class StatementFactorySpec extends ObjectBehavior
         $statement->getAuthority()->shouldBe($authority);
     }
 
-    function it_throws_an_exception_when_a_statement_is_created_without_an_actor()
+    public function it_throws_an_exception_when_a_statement_is_created_without_an_actor()
     {
         $this->withVerb(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid')));
         $this->withObject(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')));
@@ -66,7 +66,7 @@ class StatementFactorySpec extends ObjectBehavior
         $this->shouldThrow('\Xabbuh\XApi\Model\Exception\InvalidStateException')->during('createStatement');
     }
 
-    function it_throws_an_exception_when_a_statement_is_created_without_a_verb()
+    public function it_throws_an_exception_when_a_statement_is_created_without_a_verb()
     {
         $this->withActor(new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))));
         $this->withObject(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')));
@@ -74,7 +74,7 @@ class StatementFactorySpec extends ObjectBehavior
         $this->shouldThrow('\Xabbuh\XApi\Model\Exception\InvalidStateException')->during('createStatement');
     }
 
-    function it_throws_an_exception_when_a_statement_is_created_without_an_object()
+    public function it_throws_an_exception_when_a_statement_is_created_without_an_object()
     {
         $this->withActor(new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))));
         $this->withVerb(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid')));
@@ -82,7 +82,7 @@ class StatementFactorySpec extends ObjectBehavior
         $this->shouldThrow('\Xabbuh\XApi\Model\Exception\InvalidStateException')->during('createStatement');
     }
 
-    function it_can_reset_the_result()
+    public function it_can_reset_the_result()
     {
         $this->configureAllProperties();
         $this->withResult(null);
@@ -91,7 +91,7 @@ class StatementFactorySpec extends ObjectBehavior
         $statement->getResult()->shouldReturn(null);
     }
 
-    function it_can_reset_the_context()
+    public function it_can_reset_the_context()
     {
         $this->configureAllProperties();
         $this->withContext(null);
@@ -100,7 +100,7 @@ class StatementFactorySpec extends ObjectBehavior
         $statement->getContext()->shouldReturn(null);
     }
 
-    function it_can_reset_the_created()
+    public function it_can_reset_the_created()
     {
         $this->configureAllProperties();
         $this->withCreated(null);
@@ -109,7 +109,7 @@ class StatementFactorySpec extends ObjectBehavior
         $statement->getCreated()->shouldReturn(null);
     }
 
-    function it_can_reset_the_stored()
+    public function it_can_reset_the_stored()
     {
         $this->configureAllProperties();
         $this->withStored(null);
@@ -118,7 +118,7 @@ class StatementFactorySpec extends ObjectBehavior
         $statement->getStored()->shouldReturn(null);
     }
 
-    function it_can_reset_the_authority()
+    public function it_can_reset_the_authority()
     {
         $this->configureAllProperties();
         $this->withAuthority(null);

--- a/spec/StatementIdSpec.php
+++ b/spec/StatementIdSpec.php
@@ -17,37 +17,37 @@ use Xabbuh\XApi\Model\Uuid;
 
 class StatementIdSpec extends ObjectBehavior
 {
-    function it_can_be_created_from_a_uuid()
+    public function it_can_be_created_from_a_uuid()
     {
-        $this->beConstructedThrough('fromUuid', array(Uuid::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af')));
+        $this->beConstructedThrough('fromUuid', [Uuid::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af')]);
         $this->shouldBeAnInstanceOf(StatementId::class);
     }
 
-    function it_can_be_created_from_a_string()
+    public function it_can_be_created_from_a_string()
     {
-        $this->beConstructedThrough('fromString', array('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'));
+        $this->beConstructedThrough('fromString', ['39e24cc4-69af-4b01-a824-1fdc6ea8a3af']);
         $this->shouldBeAnInstanceOf(StatementId::class);
     }
 
-    function it_should_reject_malformed_uuids()
+    public function it_should_reject_malformed_uuids()
     {
-        $this->beConstructedThrough('fromString', array('bad-uuid'));
+        $this->beConstructedThrough('fromString', ['bad-uuid']);
         $this->shouldThrow('\InvalidArgumentException')->duringInstantiation();
     }
 
-    function its_value_is_a_uuid_string()
+    public function its_value_is_a_uuid_string()
     {
-        $this->beConstructedThrough('fromUuid', array(Uuid::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af')));
+        $this->beConstructedThrough('fromUuid', [Uuid::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af')]);
 
         $this->getValue()->shouldReturn('39e24cc4-69af-4b01-a824-1fdc6ea8a3af');
     }
 
-    function it_is_equal_to_statement_ids_with_equal_value()
+    public function it_is_equal_to_statement_ids_with_equal_value()
     {
         $value = '39e24cc4-69af-4b01-a824-1fdc6ea8a3af';
         $uuid = Uuid::fromString($value);
 
-        $this->beConstructedThrough('fromUuid', array($uuid));
+        $this->beConstructedThrough('fromUuid', [$uuid]);
 
         $this->equals(StatementId::fromString($value))->shouldReturn(true);
         $this->equals(StatementId::fromUuid(Uuid::fromString($value)))->shouldReturn(true);

--- a/spec/StatementReferenceSpec.php
+++ b/spec/StatementReferenceSpec.php
@@ -18,13 +18,13 @@ use Xabbuh\XApi\Model\StatementReference;
 
 class StatementReferenceSpec extends ObjectBehavior
 {
-    function it_is_an_xapi_object()
+    public function it_is_an_xapi_object()
     {
         $this->beConstructedWith(StatementId::fromString('16fd2706-8baf-433b-82eb-8c7fada847da'));
         $this->shouldHaveType(StatementObject::class);
     }
 
-    function it_is_equal_to_another_reference_with_the_same_statement_id()
+    public function it_is_equal_to_another_reference_with_the_same_statement_id()
     {
         $this->beConstructedWith(StatementId::fromString('16fd2706-8baf-433b-82eb-8c7fada847da'));
 

--- a/spec/StatementSpec.php
+++ b/spec/StatementSpec.php
@@ -30,28 +30,28 @@ use Xabbuh\XApi\Model\Verb;
 
 class StatementSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
         $id = StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af');
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith($id, $actor, $verb, $object);
     }
 
-    function its_default_version_is_null()
+    public function its_default_version_is_null()
     {
         $this->getVersion()->shouldReturn(null);
     }
 
-    function it_creates_reference_to_itself()
+    public function it_creates_reference_to_itself()
     {
         $reference = $this->getStatementReference();
         $reference->shouldBeAnInstanceOf(StatementReference::class);
         $reference->getStatementId()->equals(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'))->shouldReturn(true);
     }
 
-    function it_creates_statement_voiding_itself()
+    public function it_creates_statement_voiding_itself()
     {
         $voidingActor = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $voidingStatement = $this->getVoidStatement($voidingActor);
@@ -63,7 +63,7 @@ class StatementSpec extends ObjectBehavior
         $voidedStatement->getStatementId()->equals(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'))->shouldReturn(true);
     }
 
-    function it_can_be_authorized()
+    public function it_can_be_authorized()
     {
         $authority = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $authorizedStatement = $this->withAuthority($authority);
@@ -75,10 +75,10 @@ class StatementSpec extends ObjectBehavior
         $authorizedStatement->getObject()->equals($this->getObject())->shouldBe(true);
     }
 
-    function it_overrides_existing_authority_when_it_is_authorized()
+    public function it_overrides_existing_authority_when_it_is_authorized()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $authority = new Group(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
         $this->beConstructedWith(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'), $actor, $verb, $object, null, $authority);
@@ -94,10 +94,10 @@ class StatementSpec extends ObjectBehavior
         $authorizedStatement->getAuthority()->equals($this->getAuthority())->shouldBe(false);
     }
 
-    function its_object_can_be_an_agent()
+    public function its_object_can_be_an_agent()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'), $actor, $verb, $object);
 
@@ -105,10 +105,10 @@ class StatementSpec extends ObjectBehavior
         $this->getObject()->shouldBe($object);
     }
 
-    function it_does_not_equal_another_statement_with_different_timestamp()
+    public function it_does_not_equal_another_statement_with_different_timestamp()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'), $actor, $verb, $object, null, null, new \DateTime('2014-07-23T12:34:02-05:00'));
 
@@ -117,10 +117,10 @@ class StatementSpec extends ObjectBehavior
         $this->equals($otherStatement)->shouldBe(false);
     }
 
-    function it_equals_another_statement_with_same_timestamp()
+    public function it_equals_another_statement_with_same_timestamp()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'), $actor, $verb, $object, null, null, new \DateTime('2014-07-23T12:34:02-05:00'));
 
@@ -211,15 +211,15 @@ class StatementSpec extends ObjectBehavior
 
     public function it_returns_a_new_instance_with_attachments()
     {
-        $attachments = array(new Attachment(
+        $attachments = [new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
-        ));
+        )];
         $statement = $this->withAttachments($attachments);
 
         $statement->shouldNotBe($this);
@@ -227,7 +227,7 @@ class StatementSpec extends ObjectBehavior
         $statement->getAttachments()->shouldReturn($attachments);
     }
 
-    function it_returns_a_new_instance_with_version()
+    public function it_returns_a_new_instance_with_version()
     {
         $statement = $this->withVersion('1.0.1');
 
@@ -236,21 +236,21 @@ class StatementSpec extends ObjectBehavior
         $statement->getVersion()->shouldReturn('1.0.1');
     }
 
-    function it_ignores_array_keys_in_attachment_lists()
+    public function it_ignores_array_keys_in_attachment_lists()
     {
         $textAttachment = new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
-        $attachments = array(1 => $textAttachment);
+        $attachments = [1 => $textAttachment];
 
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith(null, $actor, $verb, $object, null, null, null, null, null, $attachments);
 
@@ -263,12 +263,12 @@ class StatementSpec extends ObjectBehavior
         $statement->getAttachments()->shouldHaveKeyWithValue(0, $textAttachment);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_this_statement_has_an_id()
+    public function it_is_not_equal_with_other_statement_if_only_this_statement_has_an_id()
     {
         $this->equals($this->withId(null))->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_an_id()
+    public function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_an_id()
     {
         $statement = $this->withId(null);
         $otherStatement = $statement->withId(StatementId::fromString('39e24cc4-69af-4b01-a824-1fdc6ea8a3af'));
@@ -276,28 +276,28 @@ class StatementSpec extends ObjectBehavior
         $statement->equals($otherStatement)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_ids_differ()
+    public function it_is_not_equal_with_other_statement_if_ids_differ()
     {
         $statement = $this->withId(StatementId::fromString('12345678-1234-5678-8234-567812345678'));
 
         $this->equals($statement)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_this_statement_has_context()
+    public function it_is_not_equal_with_other_statement_if_only_this_statement_has_context()
     {
         $statement = $this->withContext(new Context());
 
         $statement->equals($statement->withContext(null))->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_context()
+    public function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_context()
     {
         $statement = $this->withContext(new Context());
 
         $this->equals($statement)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_contexts_differ()
+    public function it_is_not_equal_with_other_statement_if_contexts_differ()
     {
         $context = new Context();
         $revisionContext = $context->withRevision('test');
@@ -307,47 +307,47 @@ class StatementSpec extends ObjectBehavior
         $this->withContext($platformContext)->equals($statement)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_this_statement_has_attachments()
+    public function it_is_not_equal_with_other_statement_if_only_this_statement_has_attachments()
     {
-        $attachments = array(new Attachment(
+        $attachments = [new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
-        ));
+        )];
         $statement = $this->withAttachments($attachments);
 
         $statement->equals($this->withAttachments(null))->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_attachments()
+    public function it_is_not_equal_with_other_statement_if_only_the_other_statement_has_attachments()
     {
-        $attachments = array(new Attachment(
+        $attachments = [new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
-        ));
+        )];
         $statement = $this->withAttachments($attachments);
 
         $this->equals($statement)->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_number_of_attachments_differs()
+    public function it_is_not_equal_with_other_statement_if_number_of_attachments_differs()
     {
         $textAttachment = new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
         $jsonAttachment = new Attachment(
@@ -355,24 +355,24 @@ class StatementSpec extends ObjectBehavior
             'application/json',
             60,
             'f4135c31e2710764604195dfe4e225884d8108467cc21670803e384b80df88ee',
-            LanguageMap::create(array('en-US' => 'JSON attachment')),
+            LanguageMap::create(['en-US' => 'JSON attachment']),
             null,
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
-        $statement = $this->withAttachments(array($textAttachment, $jsonAttachment));
+        $statement = $this->withAttachments([$textAttachment, $jsonAttachment]);
 
-        $statement->equals($statement->withAttachments(array($textAttachment)))->shouldReturn(false);
+        $statement->equals($statement->withAttachments([$textAttachment]))->shouldReturn(false);
     }
 
-    function it_is_not_equal_with_other_statement_if_attachments_differ()
+    public function it_is_not_equal_with_other_statement_if_attachments_differ()
     {
         $textAttachment = new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
         $jsonAttachment = new Attachment(
@@ -380,16 +380,16 @@ class StatementSpec extends ObjectBehavior
             'application/json',
             60,
             'f4135c31e2710764604195dfe4e225884d8108467cc21670803e384b80df88ee',
-            LanguageMap::create(array('en-US' => 'JSON attachment')),
+            LanguageMap::create(['en-US' => 'JSON attachment']),
             null,
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
-        $statement = $this->withAttachments(array($textAttachment));
+        $statement = $this->withAttachments([$textAttachment]);
 
-        $statement->equals($statement->withAttachments(array($jsonAttachment)))->shouldReturn(false);
+        $statement->equals($statement->withAttachments([$jsonAttachment]))->shouldReturn(false);
     }
 
-    function it_is_equal_with_other_statement_even_if_versions_differ()
+    public function it_is_equal_with_other_statement_even_if_versions_differ()
     {
         $statement = $this->withVersion('1.0.0');
         $otherStatement = $this->withVersion('1.0.1');

--- a/spec/StatementsFilterSpec.php
+++ b/spec/StatementsFilterSpec.php
@@ -21,13 +21,13 @@ use Xabbuh\XApi\Model\Verb;
 
 class StatementsFilterSpec extends ObjectBehavior
 {
-    function it_does_not_filter_anything_by_default()
+    public function it_does_not_filter_anything_by_default()
     {
         $filter = $this->getFilter();
         $filter->shouldHaveCount(0);
     }
 
-    function it_can_filter_by_actor()
+    public function it_can_filter_by_actor()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
         $this->byActor($actor)->shouldReturn($this);
@@ -37,18 +37,18 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('agent', $actor);
     }
 
-    function it_can_filter_by_verb()
+    public function it_can_filter_by_verb()
     {
-        $this->byVerb(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test'))))->shouldReturn($this);
+        $this->byVerb(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test'])))->shouldReturn($this);
 
         $filter = $this->getFilter();
         $filter->shouldHaveCount(1);
         $filter->shouldHaveKeyWithValue('verb', 'http://tincanapi.com/conformancetest/verbid');
     }
 
-    function it_can_filter_by_activity()
+    public function it_can_filter_by_activity()
     {
-        $iri = IRI::fromString('http://tincanapi.com/conformancetest/activityid');
+        IRI::fromString('http://tincanapi.com/conformancetest/activityid');
         $this->byActivity(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')))->shouldReturn($this);
 
         $filter = $this->getFilter();
@@ -56,7 +56,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('activity', 'http://tincanapi.com/conformancetest/activityid');
     }
 
-    function it_can_filter_by_registration()
+    public function it_can_filter_by_registration()
     {
         $this->byRegistration('foo')->shouldReturn($this);
 
@@ -65,7 +65,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('registration', 'foo');
     }
 
-    function it_can_enable_to_filter_related_activities()
+    public function it_can_enable_to_filter_related_activities()
     {
         $this->enableRelatedActivityFilter()->shouldReturn($this);
 
@@ -74,7 +74,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('related_activities', 'true');
     }
 
-    function it_can_disable_to_filter_related_activities()
+    public function it_can_disable_to_filter_related_activities()
     {
         $this->disableRelatedActivityFilter()->shouldReturn($this);
 
@@ -83,7 +83,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('related_activities', 'false');
     }
 
-    function it_can_enable_to_filter_related_agents()
+    public function it_can_enable_to_filter_related_agents()
     {
         $this->enableRelatedAgentFilter()->shouldReturn($this);
 
@@ -92,7 +92,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('related_agents', 'true');
     }
 
-    function it_can_disable_to_filter_related_agents()
+    public function it_can_disable_to_filter_related_agents()
     {
         $this->disableRelatedAgentFilter()->shouldReturn($this);
 
@@ -101,7 +101,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('related_agents', 'false');
     }
 
-    function it_can_filter_by_timestamp()
+    public function it_can_filter_by_timestamp()
     {
         $this->since(\DateTime::createFromFormat(\DateTime::ISO8601, '2013-05-18T05:32:34Z'))->shouldReturn($this);
         $this->getFilter()->shouldHaveKeyWithValue('since', '2013-05-18T05:32:34+00:00');
@@ -110,7 +110,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $this->getFilter()->shouldHaveKeyWithValue('until', '2014-05-18T05:32:34+00:00');
     }
 
-    function it_can_sort_the_result_in_ascending_order()
+    public function it_can_sort_the_result_in_ascending_order()
     {
         $this->ascending()->shouldReturn($this);
 
@@ -119,7 +119,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('ascending', 'true');
     }
 
-    function it_can_sort_the_result_in_descending_order()
+    public function it_can_sort_the_result_in_descending_order()
     {
         $this->descending()->shouldReturn($this);
 
@@ -128,7 +128,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('ascending', 'false');
     }
 
-    function it_can_limit_the_number_of_results()
+    public function it_can_limit_the_number_of_results()
     {
         $this->limit(10)->shouldReturn($this);
 
@@ -137,7 +137,7 @@ class StatementsFilterSpec extends ObjectBehavior
         $filter->shouldHaveKeyWithValue('limit', 10);
     }
 
-    function it_rejects_choosing_a_negative_number_of_results()
+    public function it_rejects_choosing_a_negative_number_of_results()
     {
         $this->shouldThrow('\InvalidArgumentException')->duringLimit(-1);
     }

--- a/spec/SubStatementSpec.php
+++ b/spec/SubStatementSpec.php
@@ -31,28 +31,28 @@ use Xabbuh\XApi\Model\Verb;
 
 class SubStatementSpec extends ObjectBehavior
 {
-    function let()
+    public function let()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith($actor, $verb, $object);
     }
 
-    function it_is_an_xapi_object()
+    public function it_is_an_xapi_object()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith($actor, $verb, $object);
 
         $this->shouldHaveType(StatementObject::class);
     }
 
-    function its_object_can_be_an_agent()
+    public function its_object_can_be_an_agent()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith($actor, $verb, $object);
 
@@ -60,10 +60,10 @@ class SubStatementSpec extends ObjectBehavior
         $this->getObject()->shouldBe($object);
     }
 
-    function it_does_not_equal_another_statement_with_different_timestamp()
+    public function it_does_not_equal_another_statement_with_different_timestamp()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith($actor, $verb, $object, null, null, new \DateTime('2014-07-23T12:34:02-05:00'));
 
@@ -72,10 +72,10 @@ class SubStatementSpec extends ObjectBehavior
         $this->equals($otherStatement)->shouldBe(false);
     }
 
-    function it_equals_another_statement_with_same_timestamp()
+    public function it_equals_another_statement_with_same_timestamp()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Agent(InverseFunctionalIdentifier::withOpenId('http://openid.tincanapi.com'));
         $this->beConstructedWith($actor, $verb, $object, null, null, new \DateTime('2014-07-23T12:34:02-05:00'));
 
@@ -84,10 +84,10 @@ class SubStatementSpec extends ObjectBehavior
         $this->equals($otherStatement)->shouldBe(true);
     }
 
-    function it_is_different_from_another_sub_statement_if_contexts_differ()
+    public function it_is_different_from_another_sub_statement_if_contexts_differ()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith($actor, $verb, $object, null, new Context());
 
@@ -100,10 +100,10 @@ class SubStatementSpec extends ObjectBehavior
             ->withInstructor(new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com'))))
             ->withTeam(new Group(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest-group@tincanapi.com'))))
             ->withContextActivities(new ContextActivities(
-                array(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))),
-                array(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))),
-                array(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))),
-                array(new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid')))
+                [new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))],
+                [new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))],
+                [new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))],
+                [new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'))]
             ))
             ->withRevision('test')
             ->withPlatform('test')
@@ -116,14 +116,14 @@ class SubStatementSpec extends ObjectBehavior
         $this->equals($subStatement)->shouldReturn(false);
     }
 
-    function it_rejects_to_hold_another_sub_statement_as_object()
+    public function it_rejects_to_hold_another_sub_statement_as_object()
     {
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $subStatement = new SubStatement($actor, $verb, $object);
 
-        $this->shouldThrow('\InvalidArgumentException')->during('__construct', array($actor, $verb, $subStatement));
+        $this->shouldThrow('\InvalidArgumentException')->during('__construct', [$actor, $verb, $subStatement]);
     }
 
     public function it_returns_a_new_instance_with_actor()
@@ -178,15 +178,15 @@ class SubStatementSpec extends ObjectBehavior
 
     public function it_returns_a_new_instance_with_attachments()
     {
-        $attachments = array(new Attachment(
+        $attachments = [new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
-        ));
+        )];
         $statement = $this->withAttachments($attachments);
 
         $statement->shouldNotBe($this);
@@ -194,21 +194,21 @@ class SubStatementSpec extends ObjectBehavior
         $statement->getAttachments()->shouldReturn($attachments);
     }
 
-    function it_ignores_array_keys_in_attachment_lists()
+    public function it_ignores_array_keys_in_attachment_lists()
     {
         $textAttachment = new Attachment(
             IRI::fromString('http://id.tincanapi.com/attachment/supporting_media'),
             'text/plain',
             18,
             'bd1a58265d96a3d1981710dab8b1e1ed04a8d7557ea53ab0cf7b44c04fd01545',
-            LanguageMap::create(array('en-US' => 'Text attachment')),
-            LanguageMap::create(array('en-US' => 'Text attachment description')),
+            LanguageMap::create(['en-US' => 'Text attachment']),
+            LanguageMap::create(['en-US' => 'Text attachment description']),
             IRL::fromString('http://tincanapi.com/conformancetest/attachment/fileUrlOnly')
         );
-        $attachments = array(1 => $textAttachment);
+        $attachments = [1 => $textAttachment];
 
         $actor = new Agent(InverseFunctionalIdentifier::withMbox(IRI::fromString('mailto:conformancetest@tincanapi.com')));
-        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(array('en-US' => 'test')));
+        $verb = new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), LanguageMap::create(['en-US' => 'test']));
         $object = new Activity(IRI::fromString('http://tincanapi.com/conformancetest/activityid'));
         $this->beConstructedWith($actor, $verb, $object, null, null, null, $attachments);
 

--- a/spec/VerbSpec.php
+++ b/spec/VerbSpec.php
@@ -18,23 +18,23 @@ use Xabbuh\XApi\Model\Verb;
 
 class VerbSpec extends ObjectBehavior
 {
-    function it_detects_voiding_verbs()
+    public function it_detects_voiding_verbs()
     {
         $this->beConstructedWith(IRI::fromString('http://adlnet.gov/expapi/verbs/voided'));
         $this->isVoidVerb()->shouldReturn(true);
     }
 
-    function its_properties_can_be_read()
+    public function its_properties_can_be_read()
     {
         $iri = IRI::fromString('http://tincanapi.com/conformancetest/verbid');
-        $languageMap = LanguageMap::create(array('en-US' => 'test'));
+        $languageMap = LanguageMap::create(['en-US' => 'test']);
         $this->beConstructedWith($iri, $languageMap);
 
         $this->getId()->shouldReturn($iri);
         $this->getDisplay()->shouldReturn($languageMap);
     }
 
-    function its_display_property_is_null_if_omitted()
+    public function its_display_property_is_null_if_omitted()
     {
         $iri = IRI::fromString('http://tincanapi.com/conformancetest/verbid');
         $this->beConstructedWith($iri);
@@ -43,22 +43,24 @@ class VerbSpec extends ObjectBehavior
         $this->getDisplay()->shouldReturn(null);
     }
 
-    function it_creates_voiding_verb_through_factory_method()
+    public function it_creates_voiding_verb_through_factory_method()
     {
-        $this->beConstructedThrough(array(Verb::class, 'createVoidVerb'));
+        $this->beConstructedThrough(function (): \Xabbuh\XApi\Model\Verb {
+            return Verb::createVoidVerb();
+        });
 
         $this->shouldHaveType(Verb::class);
         $this->isVoidVerb()->shouldReturn(true);
     }
 
-    function it_is_different_when_displays_are_omitted_and_other_verb_contains_an_empty_list_of_displays()
+    public function it_is_different_when_displays_are_omitted_and_other_verb_contains_an_empty_list_of_displays()
     {
         $this->beConstructedWith(IRI::fromString('http://tincanapi.com/conformancetest/verbid'));
 
         $this->equals(new Verb(IRI::fromString('http://tincanapi.com/conformancetest/verbid'), new LanguageMap()))->shouldReturn(false);
     }
 
-    function it_is_equal_when_verb_id_is_equal_and_display_values_are_omitted()
+    public function it_is_equal_when_verb_id_is_equal_and_display_values_are_omitted()
     {
         $this->beConstructedWith(IRI::fromString('http://tincanapi.com/conformancetest/verbid'));
 

--- a/src/Account.php
+++ b/src/Account.php
@@ -53,11 +53,6 @@ final class Account
         if ($this->name !== $account->name) {
             return false;
         }
-
-        if (!$this->homePage->equals($account->homePage)) {
-            return false;
-        }
-
-        return true;
+        return $this->homePage->equals($account->homePage);
     }
 }

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -22,16 +22,4 @@ final class Agent extends Actor
     {
         parent::__construct($iri, $name);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function equals(StatementObject $actor): bool
-    {
-        if (!parent::equals($actor)) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/src/ContextActivities.php
+++ b/src/ContextActivities.php
@@ -42,7 +42,7 @@ final class ContextActivities
         $contextActivities = clone $this;
 
         if (!is_array($contextActivities->parentActivities)) {
-            $contextActivities->parentActivities = array();
+            $contextActivities->parentActivities = [];
         }
 
         $contextActivities->parentActivities[] = $parentActivity;
@@ -63,7 +63,7 @@ final class ContextActivities
         $contextActivities = clone $this;
 
         if (!is_array($contextActivities->groupingActivities)) {
-            $contextActivities->groupingActivities = array();
+            $contextActivities->groupingActivities = [];
         }
 
         $contextActivities->groupingActivities[] = $groupingActivity;
@@ -84,7 +84,7 @@ final class ContextActivities
         $contextActivities = clone $this;
 
         if (!is_array($contextActivities->categoryActivities)) {
-            $contextActivities->categoryActivities = array();
+            $contextActivities->categoryActivities = [];
         }
 
         $contextActivities->categoryActivities[] = $categoryActivity;
@@ -105,7 +105,7 @@ final class ContextActivities
         $contextActivities = clone $this;
 
         if (!is_array($contextActivities->otherActivities)) {
-            $contextActivities->otherActivities = array();
+            $contextActivities->otherActivities = [];
         }
 
         $contextActivities->otherActivities[] = $otherActivity;

--- a/src/DocumentData.php
+++ b/src/DocumentData.php
@@ -24,9 +24,9 @@ use Xabbuh\XApi\Common\Exception\UnsupportedOperationException;
  */
 final class DocumentData implements \ArrayAccess
 {
-    private $data = array();
+    private $data = [];
 
-    public function __construct(array $data = array())
+    public function __construct(array $data = [])
     {
         $this->data = $data;
     }

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -24,7 +24,7 @@ final class Extensions implements \ArrayAccess
 
     public function __construct(\SplObjectStorage $extensions = null)
     {
-        $this->extensions = array();
+        $this->extensions = [];
 
         if (null !== $extensions) {
             foreach ($extensions as $iri) {
@@ -102,7 +102,7 @@ final class Extensions implements \ArrayAccess
             return false;
         }
 
-        foreach ($this->extensions as $iri => $value) {
+        foreach (array_keys($this->extensions) as $iri) {
             if (!array_key_exists($iri, $otherExtensions->extensions)) {
                 return false;
             }

--- a/src/Group.php
+++ b/src/Group.php
@@ -18,12 +18,12 @@ namespace Xabbuh\XApi\Model;
  */
 final class Group extends Actor
 {
-    private $members = array();
+    private $members = [];
 
     /**
      * @param Agent[] $members
      */
-    public function __construct(InverseFunctionalIdentifier $iri = null, string $name = null, array $members = array())
+    public function __construct(InverseFunctionalIdentifier $iri = null, string $name = null, array $members = [])
     {
         parent::__construct($iri, $name);
 

--- a/src/Person.php
+++ b/src/Person.php
@@ -21,27 +21,27 @@ final class Person
     /**
      * @var string[] List of names of Agents
      */
-    private $names = array();
+    private $names = [];
 
     /**
      * @var IRI[] List of mailto IRIs of Agents
      */
-    private $mboxes = array();
+    private $mboxes = [];
 
     /**
      * @var string[] List of the SHA1 hashes of mailto IRIs of Agents
      */
-    private $mboxSha1Sums = array();
+    private $mboxSha1Sums = [];
 
     /**
      * @var string[] List of openids that uniquely identify the Agents
      */
-    private $openIds = array();
+    private $openIds = [];
 
     /**
      * @var Account[] List of accounts of Agents
      */
-    private $accounts = array();
+    private $accounts = [];
 
     private function __construct()
     {

--- a/src/StateDocumentsFilter.php
+++ b/src/StateDocumentsFilter.php
@@ -21,7 +21,7 @@ class StateDocumentsFilter
     /**
      * @var array The generated filter
      */
-    private $filter = array();
+    private $filter = [];
 
     /**
      * Filter by an Activity.
@@ -55,8 +55,9 @@ class StateDocumentsFilter
 
     /**
      * Filters for State documents stored since the specified timestamp (exclusive).
+     * @param \DateTime|\DateTimeImmutable $timestamp
      */
-    public function since(\DateTime $timestamp): self
+    public function since(\DateTimeInterface $timestamp): self
     {
         $this->filter['since'] = $timestamp->format('c');
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -31,9 +31,16 @@ final class Statement
     private $version;
 
     /**
+     * @param \Xabbuh\XApi\Model\StatementId|null $id
+     * @param \Xabbuh\XApi\Model\Result|null $result
+     * @param \Xabbuh\XApi\Model\Actor|null $authority
+     * @param \DateTimeInterface|null $created
+     * @param \DateTimeInterface|null $stored
+     * @param \Xabbuh\XApi\Model\Context|null $context
      * @param Attachment[]|null $attachments
+     * @param string|null $version
      */
-    public function __construct(StatementId $id = null, Actor $actor, Verb $verb, StatementObject $object, Result $result = null, Actor $authority = null, \DateTime $created = null, \DateTime $stored = null, Context $context = null, array $attachments = null, string $version = null)
+    public function __construct(StatementId $id = null, Actor $actor, Verb $verb, StatementObject $object, Result $result = null, Actor $authority = null, \DateTimeInterface $created = null, \DateTimeInterface $stored = null, Context $context = null, array $attachments = null, string $version = null)
     {
         $this->id = $id;
         $this->actor = $actor;
@@ -100,7 +107,10 @@ final class Statement
         return $statement;
     }
 
-    public function withCreated(\DateTime $created = null): self
+    /**
+     * @param \DateTimeInterface|null $created
+     */
+    public function withCreated(\DateTimeInterface $created = null): self
     {
         $statement = clone $this;
         $statement->created = $created;
@@ -108,7 +118,10 @@ final class Statement
         return $statement;
     }
 
-    public function withStored(\DateTime $stored = null): self
+    /**
+     * @param \DateTimeInterface|null $stored
+     */
+    public function withStored(\DateTimeInterface $stored = null): self
     {
         $statement = clone $this;
         $statement->stored = $stored;
@@ -310,7 +323,7 @@ final class Statement
             return false;
         }
 
-        if ($this->created != $statement->created) {
+        if ($this->created !== $statement->created) {
             return false;
         }
 

--- a/src/StatementFactory.php
+++ b/src/StatementFactory.php
@@ -60,12 +60,18 @@ final class StatementFactory
         $this->context = $context;
     }
 
-    public function withCreated(\DateTime $created = null): void
+    /**
+     * @param \DateTimeInterface|null $created
+     */
+    public function withCreated(\DateTimeInterface $created = null): void
     {
         $this->created = $created;
     }
 
-    public function withStored(\DateTime $stored = null): void
+    /**
+     * @param \DateTimeInterface|null $stored
+     */
+    public function withStored(\DateTimeInterface $stored = null): void
     {
         $this->stored = $stored;
     }

--- a/src/StatementsFilter.php
+++ b/src/StatementsFilter.php
@@ -18,7 +18,7 @@ namespace Xabbuh\XApi\Model;
  */
 class StatementsFilter
 {
-    private $filter = array();
+    private $filter = [];
 
     /**
      * Filters by an Agent or an identified Group.
@@ -102,8 +102,9 @@ class StatementsFilter
 
     /**
      * Filters for Statements stored since the specified timestamp (exclusive).
+     * @param \DateTime|\DateTimeImmutable $timestamp
      */
-    public function since(\DateTime $timestamp): self
+    public function since(\DateTimeInterface $timestamp): self
     {
         $this->filter['since'] = $timestamp->format('c');
 
@@ -112,8 +113,9 @@ class StatementsFilter
 
     /**
      * Filters for Statements stored at or before the specified timestamp.
+     * @param \DateTime|\DateTimeImmutable $timestamp
      */
-    public function until(\DateTime $timestamp): self
+    public function until(\DateTimeInterface $timestamp): self
     {
         $this->filter['until'] = $timestamp->format('c');
 

--- a/src/SubStatement.php
+++ b/src/SubStatement.php
@@ -28,8 +28,9 @@ final class SubStatement extends StatementObject
 
     /**
      * @param Attachment[]|null $attachments
+     * @param \DateTime|\DateTimeImmutable $created
      */
-    public function __construct(Actor $actor, Verb $verb, StatementObject $object, Result $result = null, Context $context = null, \DateTime $created = null, array $attachments = null)
+    public function __construct(Actor $actor, Verb $verb, StatementObject $object, Result $result = null, Context $context = null, \DateTimeInterface $created = null, array $attachments = null)
     {
         if ($object instanceof SubStatement) {
             throw new \InvalidArgumentException('Nesting sub statements is forbidden by the xAPI spec.');
@@ -76,7 +77,10 @@ final class SubStatement extends StatementObject
         return $subStatement;
     }
 
-    public function withCreated(\DateTime $created = null): self
+    /**
+     * @param \DateTime|\DateTimeImmutable $created
+     */
+    public function withCreated(\DateTimeInterface $created = null): self
     {
         $statement = clone $this;
         $statement->created = $created;
@@ -202,7 +206,7 @@ final class SubStatement extends StatementObject
             return false;
         }
 
-        if ($this->created != $statement->created) {
+        if ($this->created !== $statement->created) {
             return false;
         }
 

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -41,11 +41,12 @@ final class Uuid
     /**
      * Generate a version 1 UUID from a host ID, sequence number, and the current time.
      *
-     * @param int|string $node     a 48-bit number representing the hardware address
+     * @param null $node a 48-bit number representing the hardware address
      *                             This number may be represented as an integer or a hexadecimal string
-     * @param int        $clockSeq a 14-bit number used to help avoid duplicates that
+     * @param int|null $clockSeq a 14-bit number used to help avoid duplicates that
      *                             could arise when the clock is set backwards in time or if the node ID
      *                             changes
+     * @throws \Exception
      */
     public static function uuid1($node = null, int $clockSeq = null): self
     {


### PR DESCRIPTION
This PR adds some tools that help automagically improve the codebase. It should also help upgrading to newer PHP versions overtime just by changing a constant :)

## Tools

### Easy-coding-standard

This tool is used for formatting the code, I configured it for clean code (no unneeded parentheses, no unused imports etc) and PSR-12 codestyle.

### Rector

This tool can automatically change code to use certain php features or convert things like DateTime to DateTimeInterface. I configured it to make use of PHP_72 features, removing dead code and some code quality changers.

## Using

I automatically configured the github actions pipeline to run code-quality tools just on the php-8.0 matrix. I also added two commands that help you run the tools locally. :)



If you want I can also add these changes to the other php-xapi projects.
